### PR TITLE
Feat/flavour fix

### DIFF
--- a/core/src/main/scala/weaponregex/model/regextree/Node.scala
+++ b/core/src/main/scala/weaponregex/model/regextree/Node.scala
@@ -119,11 +119,11 @@ case class Lookaround(expr: RegexTree, isPositive: Boolean, isLookahead: Boolean
       ")"
     )
 
-/** Independent non-capturing group node
+/** Atomic (independent, non-capturing) group node
   * @param expr The regex inside the group
   * @param location The [[weaponregex.model.Location]] of the node in the regex string
   */
-case class INCGroup(expr: RegexTree, override val location: Location) extends Node(Seq(expr), location, "(?>", ")")
+case class AtomicGroup(expr: RegexTree, override val location: Location) extends Node(Seq(expr), location, "(?>", ")")
 
 /** The enumeration of the quantifier type
   * @param syntax The syntax used to represent the quantifier type

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -331,11 +331,11 @@ abstract class Parser(val pattern: String) {
   def incGroup[_: P]: P[INCGroup] = Indexed("(?>" ~ RE ~ ")")
     .map { case (loc, expr) => INCGroup(expr, loc) }
 
-  /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`, `flagToggleGroup`, `flagNCGroup`, `lookaround` or `incGroup`
+  /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup` or `lookaround`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
   def specialConstruct[_: P]: P[RegexTree] = P(
-    namedGroup | nonCapturingGroup | flagToggleGroup | flagNCGroup | lookaround | incGroup
+    namedGroup | nonCapturingGroup | lookaround
   )
 
   /** Intermediate parsing rule for capturing-related tokens which can parse either `group` or `specialConstruct`

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -324,12 +324,13 @@ abstract class Parser(val pattern: String) {
     .map { case (loc, (angleBracket, posNeg, expr)) => Lookaround(expr, posNeg == "=", angleBracket.isEmpty, loc) }
 
   /** Parse an independent non-capturing group
-    * @return [[weaponregex.model.regextree.INCGroup]]
+    *
+    * @return [[weaponregex.model.regextree.AtomicGroup]]
     * @example `"(?>abc)"`
     * @note This is a Scala/Java-only regex syntax
     */
-  def incGroup[_: P]: P[INCGroup] = Indexed("(?>" ~ RE ~ ")")
-    .map { case (loc, expr) => INCGroup(expr, loc) }
+  def atomicGroup[_: P]: P[AtomicGroup] = Indexed("(?>" ~ RE ~ ")")
+    .map { case (loc, expr) => AtomicGroup(expr, loc) }
 
   /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup` or `lookaround`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree

--- a/core/src/main/scala/weaponregex/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJS.scala
@@ -57,4 +57,9 @@ class ParserJS private[parser] (pattern: String) extends Parser(pattern) {
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
   override def reference[_: P]: P[RegexTree] = nameReference
+
+  /** Intermediate parsing rule for meta-character tokens which can parse either `charOct`, `charHex`, `charUnicode` or `escapeChar`
+    * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
+    */
+  override def metaCharacter[_: P]: P[RegexTree] = P(charOct | charHex | charUnicode | escapeChar | controlChar)
 }

--- a/core/src/main/scala/weaponregex/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJVM.scala
@@ -40,10 +40,10 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
     Indexed("""\0""" ~ (CharIn("0-3") ~ CharIn("0-7").rep(exactly = 2) | CharIn("0-7").rep(min = 1, max = 2)).!)
       .map { case (loc, octDigits) => MetaChar("0" + octDigits, loc) }
 
-  /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`, `flagToggleGroup`, `flagNCGroup`, `lookaround` or `incGroup`
+  /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`, `flagToggleGroup`, `flagNCGroup`, `lookaround` or `atomicGroup`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
   override def specialConstruct[_: P]: P[RegexTree] = P(
-    namedGroup | nonCapturingGroup | flagToggleGroup | flagNCGroup | lookaround | incGroup
+    namedGroup | nonCapturingGroup | flagToggleGroup | flagNCGroup | lookaround | atomicGroup
   )
 }

--- a/core/src/main/scala/weaponregex/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJVM.scala
@@ -2,7 +2,7 @@ package weaponregex.parser
 
 import fastparse._
 import NoWhitespace._
-import weaponregex.model.regextree.MetaChar
+import weaponregex.model.regextree.{MetaChar, RegexTree}
 
 /** Concrete parser for JVM flavor of regex
   * @param pattern The regex pattern to be parsed
@@ -39,4 +39,11 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
   override def charOct[_: P]: P[MetaChar] =
     Indexed("""\0""" ~ (CharIn("0-3") ~ CharIn("0-7").rep(exactly = 2) | CharIn("0-7").rep(min = 1, max = 2)).!)
       .map { case (loc, octDigits) => MetaChar("0" + octDigits, loc) }
+
+  /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`, `flagToggleGroup`, `flagNCGroup`, `lookaround` or `incGroup`
+    * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
+    */
+  override def specialConstruct[_: P]: P[RegexTree] = P(
+    namedGroup | nonCapturingGroup | flagToggleGroup | flagNCGroup | lookaround | incGroup
+  )
 }

--- a/core/src/test/scala/weaponregex/model/regextree/NodeTest.scala
+++ b/core/src/test/scala/weaponregex/model/regextree/NodeTest.scala
@@ -90,8 +90,8 @@ class NodeTest extends munit.FunSuite {
     assertEquals(node4.build, "(?=A)")
   }
 
-  test("INCGroup build") {
-    val node1 = INCGroup(leafStubA, locStub)
+  test("AtomicGroup build") {
+    val node1 = AtomicGroup(leafStubA, locStub)
     assertEquals(node1.build, "(?>A)")
   }
 

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -630,134 +630,104 @@ class ParserJSTest extends munit.FunSuite {
     treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse flag toggle group i-i") {
+  test("Unparsable: flag toggle group i-i") {
     val pattern = "(?idmsuxU-idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
-        onFlags.flags.map(_.char).mkString == "idmsuxU" && offFlags.flags.map(_.char).mkString == "idmsuxU"
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse flag toggle group i-") {
+  test("Unparsable: flag toggle group i-") {
     val pattern = "(?idmsuxU-)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
-        onFlags.flags.map(_.char).mkString == "idmsuxU" && offFlags.flags.isEmpty
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse flag toggle group -i") {
+  test("Unparsable: flag toggle group -i") {
     val pattern = "(?-idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
-        onFlags.flags.isEmpty && offFlags.flags.map(_.char).mkString == "idmsuxU"
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse flag toggle group -") {
+  test("Unparsable: flag toggle group -") {
     val pattern = "(?-)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
-        onFlags.flags.isEmpty && offFlags.flags.isEmpty
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse flag toggle group i") {
+  test("Unparsable: flag toggle group i") {
     val pattern = "(?idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagToggleGroup(FlagToggle(onFlags, false, offFlags, _), _) =>
-        onFlags.flags.map(_.char).mkString == "idmsuxU" && offFlags.flags.isEmpty
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse non-capturing group with flags i-i") {
+  test("Unparsable: non-capturing group with flags i-i") {
     val pattern = "(?idmsux-idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
-        onFlags.flags.map(_.char).mkString == "idmsux" && offFlags.flags.map(_.char).mkString == "idmsux"
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse non-capturing group with flags i-") {
+  test("Unparsable: non-capturing group with flags i-") {
     val pattern = "(?idmsux-:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
-        onFlags.flags.map(_.char).mkString == "idmsux" && offFlags.flags.isEmpty
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse non-capturing group with flags -i") {
+  test("Unparsable: non-capturing group with flags -i") {
     val pattern = "(?-idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
-        onFlags.flags.isEmpty && offFlags.flags.map(_.char).mkString == "idmsux"
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse non-capturing group with flags -") {
+  test("Unparsable: non-capturing group with flags -") {
     val pattern = "(?-:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
-        onFlags.flags.isEmpty && offFlags.flags.isEmpty
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse non-capturing group with flags i") {
+  test("Unparsable: non-capturing group with flags i") {
     val pattern = "(?idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case FlagNCGroup(FlagToggle(onFlags, false, offFlags, _), _: Concat, _) =>
-        onFlags.flags.map(_.char).mkString == "idmsux" && offFlags.flags.isEmpty
-      case _ => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
   test("Parse positive lookahead") {
@@ -808,16 +778,14 @@ class ParserJSTest extends munit.FunSuite {
     treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse independent non-capturing group") {
+  test("Unparsable: independent non-capturing group") {
     val pattern = "(?>hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case INCGroup(_: Concat, _) => true
-      case _                      => false
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case _                                    => false
     })
-
-    treeBuildTest(parsedTree, pattern)
   }
 
   test("Parse named reference") {

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -305,7 +305,7 @@ class ParserJSTest extends munit.FunSuite {
   }
 
   test("Parse hexadecimal characters") {
-    val pattern = "\\x20\\u0020\\x{000020}"
+    val pattern = "\\x20\\u0020"
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
@@ -315,6 +315,18 @@ class ParserJSTest extends munit.FunSuite {
         case _                     => false
       })
     }
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse \\x{20} as quantifier") {
+    val pattern = "\\x{20}"
+    val parsedTree = Parser(pattern, parserFlavor).get
+
+    assert(clue(parsedTree) match {
+      case Quantifier(QuoteChar('x', _), 20, 20, _, GreedyQuantifier, true) => true
+      case _                                                                => false
+    })
 
     treeBuildTest(parsedTree, pattern)
   }

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -768,8 +768,8 @@ class ParserJVMTest extends munit.FunSuite {
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree) match {
-      case INCGroup(_: Concat, _) => true
-      case _                      => false
+      case AtomicGroup(_: Concat, _) => true
+      case _                         => false
     })
 
     treeBuildTest(parsedTree, pattern)


### PR DESCRIPTION
feat(parser): remove hexBrace syntax from JS parser flavor
feat(parser): move flag-related groups + INCGroup to JVM flavor only
fix(naming): Rename `INCGroup` to `AtomicGroup`