### PR TITLE
Lookaround mutator

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,28 +132,30 @@ This function will return a JavaScript Array of `Mutant` if it can be parsed, or
 
 All the supported mutators and at which mutation level they appear are shown in the table below.
 
-| Name                                                            | 1   | 2   | 3   |
+| Name                                                            |  1  |  2  |  3  |
 | --------------------------------------------------------------- | --- | --- | --- |
-| [BOLRemoval](#bolremoval)                                       | ✅  | ✅  | ✅  |
-| [EOLRemoval](#eolremoval)                                       | ✅  | ✅  | ✅  |
-| [BOL2BOI](#bol2boi)                                             |     | ✅  | ✅  |
-| [EOL2EOI](#eol2eoi)                                             |     | ✅  | ✅  |
-| [CharClassNegation](#charclassnegation)                         | ✅  |
-| [CharClassChildRemoval](#charclasschildremoval)                 |     | ✅  | ✅  |
-| [CharClassAnyChar](#charclassanychar)                           |     | ✅  | ✅  |
-| [CharClassRangeModification](#charclassrangemodification)       |     |     | ✅  |
-| [PredefCharClassNegation](#predefcharclassnegation)             | ✅  |
-| [PredefCharClassNullification](#predefcharclassnullification)   |     | ✅  | ✅  |
-| [PredefCharClassAnyChar](#predefcharclassanychar)               |     | ✅  | ✅  |
-| [QuantifierRemoval](#quantifierremoval)                         | ✅  |
-| [QuantifierNChange](#quantifiernchange)                         |     | ✅  | ✅  |
-| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     | ✅  | ✅  |
-| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     | ✅  | ✅  |
-| [QuantifierNMModification](#quantifiernmmodification)           |     | ✅  | ✅  |
-| [QuantifierShortModification](#quantifiershortmodification)     |     | ✅  | ✅  |
-| [QuantifierShortChange](#quantifiershortchange)                 |     | ✅  | ✅  |
-| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     | ✅  |
-| [GroupToNCGroup](#grouptoncgroup)                               |     | ✅  | ✅  |
+| [BOLRemoval](#bolremoval)                                       |  ✅  |  ✅  |  ✅  |
+| [EOLRemoval](#eolremoval)                                       |  ✅  |  ✅  |  ✅  |
+| [BOL2BOI](#bol2boi)                                             |     |  ✅  |  ✅  |
+| [EOL2EOI](#eol2eoi)                                             |     |  ✅  |  ✅  |
+| [CharClassNegation](#charclassnegation)                         |  ✅  |
+| [CharClassChildRemoval](#charclasschildremoval)                 |     |  ✅  |  ✅  |
+| [CharClassAnyChar](#charclassanychar)                           |     |  ✅  |  ✅  |
+| [CharClassRangeModification](#charclassrangemodification)       |     |     |  ✅  |
+| [PredefCharClassNegation](#predefcharclassnegation)             |  ✅  |
+| [PredefCharClassNullification](#predefcharclassnullification)   |     |  ✅  |  ✅  |
+| [PredefCharClassAnyChar](#predefcharclassanychar)               |     |  ✅  |  ✅  |
+| [POSIXCharClassNegation](#posixcharclassnegation)               |  ✅  |
+| [QuantifierRemoval](#quantifierremoval)                         |  ✅  |
+| [QuantifierNChange](#quantifiernchange)                         |     |  ✅  |  ✅  |
+| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     |  ✅  |  ✅  |
+| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     |  ✅  |  ✅  |
+| [QuantifierNMModification](#quantifiernmmodification)           |     |  ✅  |  ✅  |
+| [QuantifierShortModification](#quantifiershortmodification)     |     |  ✅  |  ✅  |
+| [QuantifierShortChange](#quantifiershortchange)                 |     |  ✅  |  ✅  |
+| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     |  ✅  |
+| [GroupToNCGroup](#grouptoncgroup)                               |     |  ✅  |  ✅  |
+| [LookaroundNegation](#lookaroundnegation)                       |  ✅  |  ✅  |  ✅  |
 
 ## Boundary Mutators
 
@@ -293,6 +295,17 @@ negation.
 
 [Back to table 🔝](#supported-mutators)
 
+### POSIXCharClassNegation
+
+Flips the sign of a POSIX character class.
+
+| Original    | Mutated     |
+| ----------- | ----------- |
+| `\p{Alpha}` | `\P{Alpha}` |
+| `\P{Alpha}` | `\p{Alpha}` |
+
+[Back to table 🔝](#supported-mutators)
+
 ## Quantifier mutators
 
 ### QuantifierRemoval
@@ -407,7 +420,7 @@ Change greedy quantifiers to reluctant quantifiers.
 
 [Back to table 🔝](#supported-mutators)
 
-## Group mutators
+## Group-related construct mutators
 
 ### GroupToNCGroup
 
@@ -416,6 +429,20 @@ Change a normal group to a non-capturing group.
 | Original | Mutated   |
 | -------- | --------- |
 | `(abc)`  | `(?:abc)` |
+
+[Back to table 🔝](#supported-mutators)
+
+### LookaroundNegation
+
+Flips the sign of a lookaround (lookahead, lookbehind) construct.
+
+| Original    | Mutated    |
+| ----------- | ---------- |
+| `(?=abc)`   | `(?!abc)`  |
+| `(?!abc)`   | `(?=abc)`  |
+| `(?<=abc)`  | `(?<!abc)` |
+| `(?<!abc)`  | `(?<=abc)` |
+
 
 [Back to table 🔝](#supported-mutators)
 

--- a/core/src/main/scala/weaponregex/mutator/BuiltinMutators.scala
+++ b/core/src/main/scala/weaponregex/mutator/BuiltinMutators.scala
@@ -32,7 +32,8 @@ object BuiltinMutators {
     QuantifierShortModification,
     QuantifierShortChange,
     QuantifierReluctantAddition,
-    GroupToNCGroup
+    GroupToNCGroup,
+    LookaroundNegation
   )
 
   /** Map from mutation level number to token mutators in that level

--- a/core/src/main/scala/weaponregex/mutator/CapturingMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/CapturingMutator.scala
@@ -18,3 +18,19 @@ object GroupToNCGroup extends TokenMutator {
     case _                         => Nil
   }) map (_.build)
 }
+
+/** Negate lookaround (lookahead, lookbehind) constructs
+  *
+  * ''Mutation level(s):'' 1, 2, 3
+  * @example `(?=abc)` ⟶ `(?!abc)`
+  */
+object LookaroundNegation extends TokenMutator {
+  override val name: String = "Lookaround constructs negation"
+  override val levels: Seq[Int] = Seq(1, 2, 3)
+  override val description: String = "Negate lookaround constructs (lookahead, lookbehind)"
+
+  override def mutate(token: RegexTree): Seq[String] = (token match {
+    case la: Lookaround => Seq(la.copy(isPositive = !la.isPositive))
+    case _              => Nil
+  }) map (_.build)
+}

--- a/core/src/test/scala/weaponregex/mutator/CapturingMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/CapturingMutatorTest.scala
@@ -4,7 +4,7 @@ import weaponregex.parser.Parser
 import TreeMutator._
 import weaponregex.model.mutation.Mutant
 
-class GroupMutatorTest extends munit.FunSuite {
+class CapturingMutatorTest extends munit.FunSuite {
   test("Changes capturing group to non-capturing group") {
     val pattern = "(hello)"
     val parsedTree = Parser(pattern).get
@@ -24,5 +24,22 @@ class GroupMutatorTest extends munit.FunSuite {
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
 
     assertEquals(clue(mutants), Nil)
+  }
+
+  test("Negates lookaround constructs") {
+    val pattern = "(?=abc)(?!abc)(?<=abc)(?<!abc)"
+    val parsedTree = Parser(pattern).get
+
+    val mutants: Seq[String] = parsedTree.mutate(Seq(LookaroundNegation)) map (_.pattern)
+
+    val expected: Seq[String] = Seq(
+      "(?!abc)(?!abc)(?<=abc)(?<!abc)",
+      "(?=abc)(?=abc)(?<=abc)(?<!abc)",
+      "(?=abc)(?!abc)(?<!abc)(?<!abc)",
+      "(?=abc)(?!abc)(?<=abc)(?<=abc)"
+    )
+
+    assertEquals(clue(mutants).length, expected.length)
+    expected foreach (m => assert(clue(mutants) contains clue(m)))
   }
 }

--- a/core/src/test/scala/weaponregex/mutator/TreeMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/TreeMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.model.regextree.RegexTree
 
 class TreeMutatorTest extends munit.FunSuite {
 
-  val tree: RegexTree = Parser("""^(a*|b+|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$""").get
+  val tree: RegexTree = Parser("""^(a*|b+(?=c)|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$""").get
 
   test("Filters mutators with level 1") {
     val levels = Seq(1)

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,28 +114,30 @@ This function will return a JavaScript Array of `Mutant` if it can be parsed, or
 
 All the supported mutators and at which mutation level they appear are shown in the table below.
 
-| Name                                                            | 1   | 2   | 3   |
+| Name                                                            |  1  |  2  |  3  |
 | --------------------------------------------------------------- | --- | --- | --- |
-| [BOLRemoval](#bolremoval)                                       | ✅  | ✅  | ✅  |
-| [EOLRemoval](#eolremoval)                                       | ✅  | ✅  | ✅  |
-| [BOL2BOI](#bol2boi)                                             |     | ✅  | ✅  |
-| [EOL2EOI](#eol2eoi)                                             |     | ✅  | ✅  |
-| [CharClassNegation](#charclassnegation)                         | ✅  |
-| [CharClassChildRemoval](#charclasschildremoval)                 |     | ✅  | ✅  |
-| [CharClassAnyChar](#charclassanychar)                           |     | ✅  | ✅  |
-| [CharClassRangeModification](#charclassrangemodification)       |     |     | ✅  |
-| [PredefCharClassNegation](#predefcharclassnegation)             | ✅  |
-| [PredefCharClassNullification](#predefcharclassnullification)   |     | ✅  | ✅  |
-| [PredefCharClassAnyChar](#predefcharclassanychar)               |     | ✅  | ✅  |
-| [QuantifierRemoval](#quantifierremoval)                         | ✅  |
-| [QuantifierNChange](#quantifiernchange)                         |     | ✅  | ✅  |
-| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     | ✅  | ✅  |
-| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     | ✅  | ✅  |
-| [QuantifierNMModification](#quantifiernmmodification)           |     | ✅  | ✅  |
-| [QuantifierShortModification](#quantifiershortmodification)     |     | ✅  | ✅  |
-| [QuantifierShortChange](#quantifiershortchange)                 |     | ✅  | ✅  |
-| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     | ✅  |
-| [GroupToNCGroup](#grouptoncgroup)                               |     | ✅  | ✅  |
+| [BOLRemoval](#bolremoval)                                       |  ✅  |  ✅  |  ✅  |
+| [EOLRemoval](#eolremoval)                                       |  ✅  |  ✅  |  ✅  |
+| [BOL2BOI](#bol2boi)                                             |     |  ✅  |  ✅  |
+| [EOL2EOI](#eol2eoi)                                             |     |  ✅  |  ✅  |
+| [CharClassNegation](#charclassnegation)                         |  ✅  |
+| [CharClassChildRemoval](#charclasschildremoval)                 |     |  ✅  |  ✅  |
+| [CharClassAnyChar](#charclassanychar)                           |     |  ✅  |  ✅  |
+| [CharClassRangeModification](#charclassrangemodification)       |     |     |  ✅  |
+| [PredefCharClassNegation](#predefcharclassnegation)             |  ✅  |
+| [PredefCharClassNullification](#predefcharclassnullification)   |     |  ✅  |  ✅  |
+| [PredefCharClassAnyChar](#predefcharclassanychar)               |     |  ✅  |  ✅  |
+| [POSIXCharClassNegation](#posixcharclassnegation)               |  ✅  |
+| [QuantifierRemoval](#quantifierremoval)                         |  ✅  |
+| [QuantifierNChange](#quantifiernchange)                         |     |  ✅  |  ✅  |
+| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     |  ✅  |  ✅  |
+| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     |  ✅  |  ✅  |
+| [QuantifierNMModification](#quantifiernmmodification)           |     |  ✅  |  ✅  |
+| [QuantifierShortModification](#quantifiershortmodification)     |     |  ✅  |  ✅  |
+| [QuantifierShortChange](#quantifiershortchange)                 |     |  ✅  |  ✅  |
+| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     |  ✅  |
+| [GroupToNCGroup](#grouptoncgroup)                               |     |  ✅  |  ✅  |
+| [LookaroundNegation](#lookaroundnegation)                       |  ✅  |  ✅  |  ✅  |
 
 ## Boundary Mutators
 
@@ -275,6 +277,17 @@ negation.
 
 [Back to table 🔝](#supported-mutators)
 
+### POSIXCharClassNegation
+
+Flips the sign of a POSIX character class.
+
+| Original    | Mutated     |
+| ----------- | ----------- |
+| `\p{Alpha}` | `\P{Alpha}` |
+| `\P{Alpha}` | `\p{Alpha}` |
+
+[Back to table 🔝](#supported-mutators)
+
 ## Quantifier mutators
 
 ### QuantifierRemoval
@@ -389,7 +402,7 @@ Change greedy quantifiers to reluctant quantifiers.
 
 [Back to table 🔝](#supported-mutators)
 
-## Group mutators
+## Group-related construct mutators
 
 ### GroupToNCGroup
 
@@ -398,6 +411,20 @@ Change a normal group to a non-capturing group.
 | Original | Mutated   |
 | -------- | --------- |
 | `(abc)`  | `(?:abc)` |
+
+[Back to table 🔝](#supported-mutators)
+
+### LookaroundNegation
+
+Flips the sign of a lookaround (lookahead, lookbehind) construct.
+
+| Original    | Mutated    |
+| ----------- | ---------- |
+| `(?=abc)`   | `(?!abc)`  |
+| `(?!abc)`   | `(?=abc)`  |
+| `(?<=abc)`  | `(?<!abc)` |
+| `(?<!abc)`  | `(?<=abc)` |
+
 
 [Back to table 🔝](#supported-mutators)
 


### PR DESCRIPTION
- Add `LookaroundNegation` mutator _(Levels: 1, 2, 3)_ for negating lookaround (lookahead, lookbehind) constructs + test
- Add `POSIXCharClassNegation` and `LookaroundNegation` to the `README.md`