### PR TITLE
Fix/null or

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The current supported versions for Scala are: `2.12` and `2.13`.
 Add Weapon regeX to your `build.sbt`.
 
 ```scala
-libraryDependencies += "io.stryker-mutator" %% "weapon-regex" % "0.4.1"
+libraryDependencies += "io.stryker-mutator" %% "weapon-regex" % "0.4.2"
 ```
 
 Mutate!

--- a/core/src/main/scala/weaponregex/model/regextree/Leaf.scala
+++ b/core/src/main/scala/weaponregex/model/regextree/Leaf.scala
@@ -114,7 +114,7 @@ case class QuoteChar(char: Char, override val location: Location) extends Leaf(c
 case class Quote(quote: String, hasEnd: Boolean, override val location: Location)
     extends Leaf(quote, location, """\Q""", if (hasEnd) """\E""" else "")
 
-/** Nothing leaf (empty string)
+/** Empty string (nothing, null) leaf
   * @param location The [[weaponregex.model.Location]] of the node in the regex string
   */
-case class Nothing(override val location: Location) extends Leaf("", location)
+case class Empty(override val location: Location) extends Leaf("", location)

--- a/core/src/main/scala/weaponregex/model/regextree/Leaf.scala
+++ b/core/src/main/scala/weaponregex/model/regextree/Leaf.scala
@@ -113,3 +113,8 @@ case class QuoteChar(char: Char, override val location: Location) extends Leaf(c
   */
 case class Quote(quote: String, hasEnd: Boolean, override val location: Location)
     extends Leaf(quote, location, """\Q""", if (hasEnd) """\E""" else "")
+
+/** Nothing leaf (empty string)
+  * @param location The [[weaponregex.model.Location]] of the node in the regex string
+  */
+case class Nothing(override val location: Location) extends Leaf("", location)

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -402,16 +402,17 @@ abstract class Parser(val pattern: String) {
     .map { case (loc, nodes) => Concat(nodes, loc) }
 
   /** Parse an empty string
-    * @return [[weaponregex.model.regextree.Nothing]] tree node
+    *
+    * @return [[weaponregex.model.regextree.Empty]] tree node
     * @example `""`
     */
-  def nothing[_: P]: P[Nothing] = Indexed("")
-    .map { case (loc, _) => Nothing(loc) }
+  def empty[_: P]: P[Empty] = Indexed("")
+    .map { case (loc, _) => Empty(loc) }
 
-  /** Intermediate parsing rule which can parse either `concat`, `basicRE` or `nothing`
+  /** Intermediate parsing rule which can parse either `concat`, `basicRE` or `empty`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
-  def simpleRE[_: P]: P[RegexTree] = P(concat | basicRE | nothing)
+  def simpleRE[_: P]: P[RegexTree] = P(concat | basicRE | empty)
 
   /** Parse an 'or' (`|`) of `simpleRE`
     * @return [[weaponregex.model.regextree.Or]] tree node

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -401,10 +401,17 @@ abstract class Parser(val pattern: String) {
   def concat[_: P]: P[Concat] = Indexed(basicRE.rep(2))
     .map { case (loc, nodes) => Concat(nodes, loc) }
 
-  /** Intermediate parsing rule which can parse either `concat` or `basicRE`
+  /** Parse an empty string
+    * @return [[weaponregex.model.regextree.Nothing]] tree node
+    * @example `""`
+    */
+  def nothing[_: P]: P[Nothing] = Indexed("")
+    .map { case (loc, _) => Nothing(loc) }
+
+  /** Intermediate parsing rule which can parse either `concat`, `basicRE` or `nothing`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
-  def simpleRE[_: P]: P[RegexTree] = P(concat | basicRE)
+  def simpleRE[_: P]: P[RegexTree] = P(concat | basicRE | nothing)
 
   /** Parse an 'or' (`|`) of `simpleRE`
     * @return [[weaponregex.model.regextree.Or]] tree node

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -66,6 +66,31 @@ class ParserJSTest extends munit.FunSuite {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Parse or of characters with null children") {
+    val pattern = "|h|e||l|||l|o|"
+    val parsedTree = Parser(pattern, parserFlavor).get
+    assert(clue(parsedTree).isInstanceOf[Or])
+
+    assert(clue(parsedTree.children) match {
+      case Seq(
+            Nothing(_),
+            Character('h', _),
+            Character('e', _),
+            Nothing(_),
+            Character('l', _),
+            Nothing(_),
+            Nothing(_),
+            Character('l', _),
+            Character('o', _),
+            Nothing(_)
+          ) =>
+        true
+      case _ => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
   test("Parse BOL and EOL") {
     val pattern = "^hello$"
     val parsedTree = Parser(pattern, parserFlavor).get

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -73,16 +73,16 @@ class ParserJSTest extends munit.FunSuite {
 
     assert(clue(parsedTree.children) match {
       case Seq(
-            Nothing(_),
+            Empty(_),
             Character('h', _),
             Character('e', _),
-            Nothing(_),
+            Empty(_),
             Character('l', _),
-            Nothing(_),
-            Nothing(_),
+            Empty(_),
+            Empty(_),
             Character('l', _),
             Character('o', _),
-            Nothing(_)
+            Empty(_)
           ) =>
         true
       case _ => false

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -73,16 +73,16 @@ class ParserJVMTest extends munit.FunSuite {
 
     assert(clue(parsedTree.children) match {
       case Seq(
-            Nothing(_),
+            Empty(_),
             Character('h', _),
             Character('e', _),
-            Nothing(_),
+            Empty(_),
             Character('l', _),
-            Nothing(_),
-            Nothing(_),
+            Empty(_),
+            Empty(_),
             Character('l', _),
             Character('o', _),
-            Nothing(_)
+            Empty(_)
           ) =>
         true
       case _ => false

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -66,6 +66,31 @@ class ParserJVMTest extends munit.FunSuite {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Parse or of characters with null children") {
+    val pattern = "|h|e||l|||l|o|"
+    val parsedTree = Parser(pattern, parserFlavor).get
+    assert(clue(parsedTree).isInstanceOf[Or])
+
+    assert(clue(parsedTree.children) match {
+      case Seq(
+            Nothing(_),
+            Character('h', _),
+            Character('e', _),
+            Nothing(_),
+            Character('l', _),
+            Nothing(_),
+            Nothing(_),
+            Character('l', _),
+            Character('o', _),
+            Nothing(_)
+          ) =>
+        true
+      case _ => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
   test("Parse BOL and EOL") {
     val pattern = "^hello$"
     val parsedTree = Parser(pattern, parserFlavor).get

--- a/design/Grammar.ebnf
+++ b/design/Grammar.ebnf
@@ -4,6 +4,7 @@ RE = or
 
 simpleRE = concat
          | basicRE
+         | empty
          ;
 
 basicRE = quantifier
@@ -151,3 +152,4 @@ hex = ? [0-9a-fA-F] ? ;
 alpha = ? [a-zA-Z] ? ;
 idmsux = ? [idmsux] ? ;
 idmsuxU = ? [idmsuxU] ? ;
+empty = '';

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ The current supported versions for Scala are: `2.12` and `2.13`.
 Add Weapon regeX to your `build.sbt`.
 
 ```scala
-libraryDependencies += "io.stryker-mutator" %% "weapon-regex" % "0.4.1"
+libraryDependencies += "io.stryker-mutator" %% "weapon-regex" % "0.4.2"
 ```
 
 Mutate!


### PR DESCRIPTION
Allows parsing Or syntax with empty characters as children `foo|`, `|foo`, `fo||o`. 
Additionally allows parsing an empty regex pattern.