### PR TITLE
Charclass intersection

### DIFF
--- a/core/src/main/scala/weaponregex/model/regextree/Node.scala
+++ b/core/src/main/scala/weaponregex/model/regextree/Node.scala
@@ -39,13 +39,13 @@ abstract class Node(
   * @param isPositive `true` if the character class is positive, `false` otherwise
   */
 case class CharacterClass(nodes: Seq[RegexTree], override val location: Location, isPositive: Boolean = true)
-    extends Node(nodes, location, if (isPositive) "[" else "[^", "]") {}
+    extends Node(nodes, location, if (isPositive) "[" else "[^", "]")
 
-/** Character class node without square brackets
+/** Character class node without the surround syntactical symbols, i.e. "naked"
   * @param nodes The child nodes contained in the character class
   * @param location The [[weaponregex.model.Location]] of the node in the regex string
   */
-case class CharacterClassNaked(nodes: Seq[RegexTree], override val location: Location) extends Node(nodes, location) {}
+case class CharacterClassNaked(nodes: Seq[RegexTree], override val location: Location) extends Node(nodes, location)
 
 /** Character class intersection used inside a character class
   * @param nodes The nodes that are being "or-ed"

--- a/core/src/main/scala/weaponregex/model/regextree/Node.scala
+++ b/core/src/main/scala/weaponregex/model/regextree/Node.scala
@@ -41,6 +41,19 @@ abstract class Node(
 case class CharacterClass(nodes: Seq[RegexTree], override val location: Location, isPositive: Boolean = true)
     extends Node(nodes, location, if (isPositive) "[" else "[^", "]") {}
 
+/** Character class node without square brackets
+  * @param nodes The child nodes contained in the character class
+  * @param location The [[weaponregex.model.Location]] of the node in the regex string
+  */
+case class CharacterClassNaked(nodes: Seq[RegexTree], override val location: Location) extends Node(nodes, location) {}
+
+/** Character class intersection used inside a character class
+  * @param nodes The nodes that are being "or-ed"
+  * @param location The [[weaponregex.model.Location]] of the node in the regex string
+  */
+case class CharClassIntersection(nodes: Seq[RegexTree], override val location: Location)
+    extends Node(nodes, location, sep = "&&")
+
 /** Character range that is used inside of a character class
   * @param from The left bound of the range
   * @param to The right bound of the range

--- a/core/src/main/scala/weaponregex/mutator/CharClassMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/CharClassMutator.scala
@@ -30,8 +30,9 @@ object CharClassChildRemoval extends TokenMutator {
   override val description: String = "Remove a child character class"
 
   override def mutate(token: RegexTree): Seq[String] = token match {
-    case cc: CharacterClass if cc.children.length > 1 => cc.children map (child => cc.buildWhile(_ ne child))
-    case _                                            => Nil
+    case cc: CharacterClass if cc.children.length > 1      => cc.children map (child => cc.buildWhile(_ ne child))
+    case cc: CharacterClassNaked if cc.children.length > 1 => cc.children map (child => cc.buildWhile(_ ne child))
+    case _                                                 => Nil
   }
 }
 

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -171,7 +171,8 @@ abstract class Parser(val pattern: String) {
   def charClassCharLiteral[_: P]: P[Character] = Indexed(CharPred(!charClassSpecialChars.contains(_)).!)
     .map { case (loc, c) => Character(c.head, loc) }
 
-  /** Intermediate parsing rule for character class item tokens which can parse either `charClass`, `preDefinedCharClass`, `metaCharacter`, `range`, `quoteChar`, or `charClassCharLiteral`
+  /** Intermediate parsing rule for character class item tokens which can parse either
+    * `charClass`, `preDefinedCharClass`, `metaCharacter`, `range`, `quoteChar`, or `charClassCharLiteral`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
   def classItem[_: P]: P[RegexTree] = P(
@@ -386,7 +387,8 @@ abstract class Parser(val pattern: String) {
     */
   def quote[_: P]: P[RegexTree] = P(quoteLong | quoteChar)
 
-  /** Intermediate parsing rule which can parse either `capturing`, `anyDot`, `preDefinedCharClass`, `boundary`, `charClass`, `reference`, `character` or `quote`
+  /** Intermediate parsing rule which can parse either
+    * `capturing`, `anyDot`, `preDefinedCharClass`, `boundary`, `charClass`, `reference`, `character` or `quote`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
   def elementaryRE[_: P]: P[RegexTree] = P(

--- a/core/src/main/scala/weaponregex/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJVM.scala
@@ -3,6 +3,10 @@ package weaponregex.parser
 import fastparse._
 import NoWhitespace._
 import weaponregex.model.regextree.{MetaChar, RegexTree}
+import weaponregex.model.regextree.CharacterClass
+import weaponregex.model.regextree.CharClassIntersection
+import weaponregex.model.regextree.CharacterClassNaked
+import weaponregex.model.regextree.Character
 
 /** Concrete parser for JVM flavor of regex
   * @param pattern The regex pattern to be parsed
@@ -17,7 +21,7 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
 
   /** Special characters within a character class
     */
-  override val charClassSpecialChars: String = """[]\"""
+  override val charClassSpecialChars: String = """[]\&"""
 
   /** Allowed boundary meta-characters
     */
@@ -43,6 +47,39 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
   override def charOct[_: P]: P[MetaChar] =
     Indexed("""\0""" ~ (CharIn("0-3") ~ CharIn("0-7").rep(exactly = 2) | CharIn("0-7").rep(min = 1, max = 2)).!)
       .map { case (loc, octDigits) => MetaChar("0" + octDigits, loc) }
+
+  /** Parse a single literal character that is allowed to be in a character class
+    * @return [[weaponregex.model.regextree.Character]] tree node
+    * @example `"{"`
+    * @see [[weaponregex.parser.Parser.charClassSpecialChars]]
+    */
+  override def charClassCharLiteral[_: P]: P[Character] =
+    Indexed(CharPred(!charClassSpecialChars.contains(_)).! | "&".! ~ !"&")
+      .map { case (loc, c) => Character(c.head, loc) }
+
+  /** Parse a sequence of character class items as a 'naked character class'. It is used only inside the character class intersection.
+    *
+    * @return [[weaponregex.model.regextree.CharacterClassNaked]] tree node
+    */
+  def charClassNaked[_: P]: P[CharacterClassNaked] = Indexed(classItem.rep(minCharClassItem))
+    .map { case (loc, nodes) => CharacterClassNaked(nodes, loc) }
+
+  /** Parse a character class intersection used inside a character class.
+    *
+    * @return [[weaponregex.model.regextree.CharClassIntersection]] tree node
+    * @example `"abc&&[^bc]&&a-z"`
+    */
+  def charClassIntersection[_: P]: P[CharClassIntersection] =
+    Indexed(charClassNaked.rep(2, sep = "&&"))
+      .map { case (loc, nodes) => CharClassIntersection(nodes, loc) }
+
+  /** Parse a character class
+    * @return [[weaponregex.model.regextree.CharacterClass]] tree node
+    * @example `"[abc]"`
+    */
+  override def charClass[_: P]: P[CharacterClass] =
+    Indexed("[" ~ "^".!.? ~ (charClassIntersection.rep(exactly = 1) | classItem.rep(minCharClassItem)) ~ "]")
+      .map { case (loc, (hat, nodes)) => CharacterClass(nodes, loc, isPositive = hat.isEmpty) }
 
   /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`, `flagToggleGroup`, `flagNCGroup`, `lookaround` or `atomicGroup`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree

--- a/core/src/main/scala/weaponregex/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJVM.scala
@@ -57,9 +57,9 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
     Indexed(CharPred(!charClassSpecialChars.contains(_)).! | "&".! ~ !"&")
       .map { case (loc, c) => Character(c.head, loc) }
 
-  /** Parse a sequence of character class items as a 'naked character class'. It is used only inside the character class intersection.
-    *
+  /** Parse a character class content without the surround syntactical symbols, i.e. "naked"
     * @return [[weaponregex.model.regextree.CharacterClassNaked]] tree node
+    * @note This is used only inside the [[weaponregex.parser.ParserJVM.charClassIntersection]]
     */
   def charClassNaked[_: P]: P[CharacterClassNaked] = Indexed(classItem.rep(minCharClassItem))
     .map { case (loc, nodes) => CharacterClassNaked(nodes, loc) }
@@ -81,7 +81,8 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
     Indexed("[" ~ "^".!.? ~ (charClassIntersection.rep(exactly = 1) | classItem.rep(minCharClassItem)) ~ "]")
       .map { case (loc, (hat, nodes)) => CharacterClass(nodes, loc, isPositive = hat.isEmpty) }
 
-  /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`, `flagToggleGroup`, `flagNCGroup`, `lookaround` or `atomicGroup`
+  /** Intermediate parsing rule for special construct tokens which can parse either
+    * `namedGroup`, `nonCapturingGroup`, `flagToggleGroup`, `flagNCGroup`, `lookaround` or `atomicGroup`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
   override def specialConstruct[_: P]: P[RegexTree] = P(

--- a/core/src/test/scala/weaponregex/model/regextree/LeafTest.scala
+++ b/core/src/test/scala/weaponregex/model/regextree/LeafTest.scala
@@ -40,6 +40,16 @@ class LeafTest extends munit.FunSuite {
     assertEquals(node2.build, """\W""")
   }
 
+  test("POSIXCharClass build") {
+    val node1 = POSIXCharClass("hello_World_0123", locStub)
+    assertEquals(node1.build, """\p{hello_World_0123}""")
+  }
+
+  test("POSIXCharClass build negated") {
+    val node1 = POSIXCharClass("hello_World_0123", locStub, isPositive = false)
+    assertEquals(node1.build, """\P{hello_World_0123}""")
+  }
+
   test("BOL build") {
     val node1 = BOL(locStub)
     assertEquals(node1.build, "^")

--- a/core/src/test/scala/weaponregex/model/regextree/NodeTest.scala
+++ b/core/src/test/scala/weaponregex/model/regextree/NodeTest.scala
@@ -16,6 +16,16 @@ class NodeTest extends munit.FunSuite {
     assertEquals(node2.build, "[^ABC]")
   }
 
+  test("CharacterClassNaked build") {
+    val node1 = CharacterClassNaked(Seq(leafStubA, leafStubB, leafStubC), locStub)
+    assertEquals(node1.build, "ABC")
+  }
+
+  test("CharClassIntersection build") {
+    val node1 = CharClassIntersection(Seq(leafStubA, leafStubB, leafStubC), locStub)
+    assertEquals(node1.build, "A&&B&&C")
+  }
+
   test("Range build") {
     val node1 = Range(leafStubA, leafStubC, locStub)
     assertEquals(node1.build, "A-C")
@@ -172,5 +182,4 @@ class NodeTest extends munit.FunSuite {
     val node2 = Or(Seq(leafStubA, leafStubB, leafStubC), locStub)
     assertEquals(node2.build, "A|B|C")
   }
-
 }

--- a/core/src/test/scala/weaponregex/mutator/CharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/CharClassMutatorTest.scala
@@ -48,6 +48,27 @@ class CharClassMutatorTest extends munit.FunSuite {
     expected foreach (m => assert(clue(mutants) contains clue(m)))
   }
 
+  test("Removes children of Naked Character Classes") {
+    val pattern = "[abc&&def&&[gh]]"
+    val parsedTree = Parser(pattern).get
+
+    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
+
+    val expected: Seq[String] = Seq(
+      "[bc&&def&&[gh]]",
+      "[ac&&def&&[gh]]",
+      "[ab&&def&&[gh]]",
+      "[abc&&ef&&[gh]]",
+      "[abc&&df&&[gh]]",
+      "[abc&&de&&[gh]]",
+      "[abc&&def&&[h]]",
+      "[abc&&def&&[g]]"
+    )
+
+    assertEquals(clue(mutants).length, expected.length)
+    expected foreach (m => assert(clue(mutants) contains clue(m)))
+  }
+
   test("Does not mutate (remove children) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
     val parsedTree = Parser(pattern).get

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -25,8 +25,8 @@ class ParserJSTest extends ParserTest {
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
-    assert(parsedTree.children(0).isInstanceOf[Quantifier])
-    assert(parsedTree.children(1) match {
+    assert(parsedTree.children.head.isInstanceOf[Quantifier])
+    assert(parsedTree.children.last match {
       case Character('}', _) => true
       case _                 => false
     })
@@ -39,8 +39,8 @@ class ParserJSTest extends ParserTest {
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
-    assert(parsedTree.children(0).isInstanceOf[CharacterClass])
-    assert(parsedTree.children(1) match {
+    assert(parsedTree.children.head.isInstanceOf[CharacterClass])
+    assert(parsedTree.children.last match {
       case Character(']', _) => true
       case _                 => false
     })
@@ -248,7 +248,7 @@ class ParserJSTest extends ParserTest {
   }
 
   test("Parse character class with POSIX character classes") {
-    val pattern = """[\p{Alpha}\P{Alpha}]"""
+    val pattern = """[\p{Alpha}\P{hello_World_0123}]"""
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
@@ -257,8 +257,8 @@ class ParserJSTest extends ParserTest {
       case _                                => false
     })
     assert(clue(parsedTree.children.last) match {
-      case POSIXCharClass("Alpha", _, false) => true
-      case _                                 => false
+      case POSIXCharClass("hello_World_0123", _, false) => true
+      case _                                            => false
     })
 
     treeBuildTest(parsedTree, pattern)
@@ -408,7 +408,7 @@ class ParserJSTest extends ParserTest {
   }
 
   test("Parse POSIX character classes") {
-    val pattern = """\p{Alpha}\P{Alpha}"""
+    val pattern = """\p{Alpha}\P{hello_World_0123}"""
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
@@ -417,8 +417,8 @@ class ParserJSTest extends ParserTest {
       case _                                => false
     })
     assert(clue(parsedTree.children.last) match {
-      case POSIXCharClass("Alpha", _, false) => true
-      case _                                 => false
+      case POSIXCharClass("hello_World_0123", _, false) => true
+      case _                                            => false
     })
 
     treeBuildTest(parsedTree, pattern)
@@ -606,16 +606,16 @@ class ParserJSTest extends ParserTest {
   }
 
   test("Parse named capturing group") {
-    val pattern = "(?<name1>hello)(?<name2>world)"
+    val pattern = "(?<groupName1>hello)(?<GroupName2>world)"
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
-    assert(clue(parsedTree.children(0)) match {
-      case NamedGroup(_: Concat, name, _) => name == "name1"
+    assert(clue(parsedTree.children.head) match {
+      case NamedGroup(_: Concat, name, _) => name == "groupName1"
       case _                              => false
     })
-    assert(clue(parsedTree.children(1)) match {
-      case NamedGroup(_: Concat, name, _) => name == "name2"
+    assert(clue(parsedTree.children.last) match {
+      case NamedGroup(_: Concat, name, _) => name == "GroupName2"
       case _                              => false
     })
 
@@ -623,14 +623,14 @@ class ParserJSTest extends ParserTest {
   }
 
   test("Parse nested named capturing group") {
-    val pattern = "(?<name1>hello(?<name2>world))"
+    val pattern = "(?<groupName1>hello(?<GroupName2>world))"
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree) match {
-      case NamedGroup(Concat(nodes, _), "name1", _) =>
+      case NamedGroup(Concat(nodes, _), "groupName1", _) =>
         assert(clue(nodes.last) match {
-          case NamedGroup(_: Concat, "name2", _) => true
-          case _                                 => false
+          case NamedGroup(_: Concat, "GroupName2", _) => true
+          case _                                      => false
         })
         true
       case _ => false


### PR DESCRIPTION
This pullrequest contains the implementation for parsing character class intersections inside a character class like: `[a-z&&[abc]]`.

This is only possible in the JVM regex flavor. With this update, the `&` character becomes a special character inside the character class. It can only be parsed as a character literal if it is not followed by another `&`, hence the negative look ahead in the `charClassCharLiteral` rule. For example `[abc&&]` is an invalid regex, but `[abc&&&]` is. This is the case because the 3rd `&` is not followed by another, so it is parsed as a character literal while the others signify an intersection.

I also added the CharacterClassNaked node to the nodes mutated by the CharClassChildRemoval mutator, otherwise this mutator would not generate any mutants for a regex like `[abc&&def&&ghi]`, because the root character class only has the intersection node as child.