### PR TITLE
`TokenMutator` returns `Mutant`s and more precise mutation location

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // Skip publish root
-skip in publish := true
+publish / skip := true
 
 val Scala212 = "2.12.13"
 val Scala213 = "2.13.5"
@@ -8,25 +8,25 @@ inThisBuild(
   List(
     organization := "io.stryker-mutator",
     homepage := Some(url("https://github.com/stryker-mutator/weapon-regex")),
-    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    licenses := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
       Developer(
         id = "nhat",
         name = "Nhat",
         email = "",
-        url = url("http://github.com/Nhaajt")
+        url = url("https://github.com/Nhaajt")
       ),
       Developer(
         id = "jan",
         name = "Jan",
         email = "",
-        url = url("http://github.com/JSmits-utwente")
+        url = url("https://github.com/JSmits-utwente")
       ),
       Developer(
         id = "wijtse",
         name = "Wijtse",
         email = "",
-        url = url("http://github.com/wijtserekker")
+        url = url("https://github.com/wijtserekker")
       )
     )
   )

--- a/core/src/main/scala/weaponregex/model/mutation/TokenMutator.scala
+++ b/core/src/main/scala/weaponregex/model/mutation/TokenMutator.scala
@@ -54,6 +54,9 @@ trait TokenMutator {
     /** Convert a mutated pattern string into a [[weaponregex.model.mutation.Mutant]]
       * with the [[weaponregex.model.Location]] starts from the start of the provided token
       * and ends at the start of the token's first child
+      *
+      * If the given token has no child, the location of the given token is considered
+      * to be the location of the mutant
       * @param token The token for reference
       * @return A [[weaponregex.model.mutation.Mutant]]
       */
@@ -67,6 +70,9 @@ trait TokenMutator {
     /** Convert a mutated pattern string into a [[weaponregex.model.mutation.Mutant]]
       * with the [[weaponregex.model.Location]] starts from the end of the provided token's last child
       * and ends at the end of the token
+      *
+      * If the given token has no child, the location of the given token is considered
+      * to be the location of the mutant
       * @param token The token for reference
       * @return A [[weaponregex.model.mutation.Mutant]]
       */

--- a/core/src/main/scala/weaponregex/model/mutation/TokenMutator.scala
+++ b/core/src/main/scala/weaponregex/model/mutation/TokenMutator.scala
@@ -1,5 +1,6 @@
 package weaponregex.model.mutation
 
+import weaponregex.model.Location
 import weaponregex.model.regextree.RegexTree
 
 trait TokenMutator {
@@ -18,13 +19,62 @@ trait TokenMutator {
 
   /** Apply mutation to the given token
     * @param token Target token
-    * @return Sequence of strings, which are mutations of the original token
+    * @return Sequence of [[weaponregex.model.mutation.Mutant]]
     */
-  final def apply(token: RegexTree): Seq[String] = mutate(token)
+  final def apply(token: RegexTree): Seq[Mutant] = mutate(token)
 
   /** Mutate the given token
     * @param token Target token
-    * @return Sequence of strings, which are mutations of the original token
+    * @return Sequence of [[weaponregex.model.mutation.Mutant]]
     */
-  def mutate(token: RegexTree): Seq[String]
+  def mutate(token: RegexTree): Seq[Mutant]
+
+  /** Extension class for a mutated pattern string
+    * to convert it into a [[weaponregex.model.mutation.Mutant]]
+    * using the information of the current token mutator
+    * @param pattern The string pattern to be converted
+    */
+  implicit protected class MutatedPatternExtension(pattern: String) {
+
+    /** Convert a mutated pattern string into a [[weaponregex.model.mutation.Mutant]]
+      * at the provided [[weaponregex.model.Location]]
+      * @param location [[weaponregex.model.Location]] of the mutation
+      * @return A [[weaponregex.model.mutation.Mutant]]
+      */
+    def toMutantAt(location: Location): Mutant =
+      Mutant(pattern, name, location, levels, description)
+
+    /** Convert a mutated pattern string into a [[weaponregex.model.mutation.Mutant]]
+      * with the [[weaponregex.model.Location]] taken from the provided token
+      * @param token The token for reference
+      * @return A [[weaponregex.model.mutation.Mutant]]
+      */
+    def toMutantOf(token: RegexTree): Mutant = toMutantAt(token.location)
+
+    /** Convert a mutated pattern string into a [[weaponregex.model.mutation.Mutant]]
+      * with the [[weaponregex.model.Location]] starts from the start of the provided token
+      * and ends at the start of the token's first child
+      * @param token The token for reference
+      * @return A [[weaponregex.model.mutation.Mutant]]
+      */
+    def toMutantBeforeChildrenOf(token: RegexTree): Mutant = {
+      val loc: Location =
+        if (token.children.isEmpty) token.location
+        else Location(token.location.start, token.children.head.location.start)
+      toMutantAt(loc)
+    }
+
+    /** Convert a mutated pattern string into a [[weaponregex.model.mutation.Mutant]]
+      * with the [[weaponregex.model.Location]] starts from the end of the provided token's last child
+      * and ends at the end of the token
+      * @param token The token for reference
+      * @return A [[weaponregex.model.mutation.Mutant]]
+      */
+    def toMutantAfterChildrenOf(token: RegexTree): Mutant = {
+      val loc: Location =
+        if (token.children.isEmpty) token.location
+        else Location(token.children.last.location.end, token.location.end)
+      toMutantAt(loc)
+    }
+  }
 }

--- a/core/src/main/scala/weaponregex/mutator/BoundaryMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/BoundaryMutator.scala
@@ -1,6 +1,6 @@
 package weaponregex.mutator
 
-import weaponregex.model.mutation.TokenMutator
+import weaponregex.model.mutation.{Mutant, TokenMutator}
 import weaponregex.model.regextree._
 
 /** Remove beginning of line character `^`
@@ -13,10 +13,10 @@ object BOLRemoval extends TokenMutator {
   override val levels: Seq[Int] = Seq(1, 2, 3)
   override val description: String = "Remove beginning of line character `^`"
 
-  override def mutate(token: RegexTree): Seq[String] = token.children.foldLeft(Seq.empty[String])((results, child) =>
+  override def mutate(token: RegexTree): Seq[Mutant] = token.children.foldLeft(Seq.empty[Mutant])((mutants, child) =>
     child match {
-      case _: BOL => results :+ token.buildWhile(_ ne child)
-      case _      => results
+      case _: BOL => mutants :+ token.buildWhile(_ ne child).toMutantOf(child)
+      case _      => mutants
     }
   )
 }
@@ -31,10 +31,10 @@ object EOLRemoval extends TokenMutator {
   override val levels: Seq[Int] = Seq(1, 2, 3)
   override val description: String = "Remove end of line character `$`"
 
-  override def mutate(token: RegexTree): Seq[String] = token.children.foldLeft(Seq.empty[String])((results, child) =>
+  override def mutate(token: RegexTree): Seq[Mutant] = token.children.foldLeft(Seq.empty[Mutant])((mutants, child) =>
     child match {
-      case _: EOL => results :+ token.buildWhile(_ ne child)
-      case _      => results
+      case _: EOL => mutants :+ token.buildWhile(_ ne child).toMutantOf(child)
+      case _      => mutants
     }
   )
 }
@@ -49,10 +49,10 @@ object BOL2BOI extends TokenMutator {
   override val levels: Seq[Int] = Seq(2, 3)
   override val description: String = """Change beginning of line `^` to beginning of input `\A`"""
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case _: BOL => Seq(Boundary("A", token.location))
     case _      => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantOf(token))
 }
 
 /** Change end of line `$` to end pf input `\z`
@@ -65,8 +65,8 @@ object EOL2EOI extends TokenMutator {
   override val levels: Seq[Int] = Seq(2, 3)
   override val description: String = """Change end of line `$` to end of input `\z`"""
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case _: EOL => Seq(Boundary("z", token.location))
     case _      => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantOf(token))
 }

--- a/core/src/main/scala/weaponregex/mutator/CapturingMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/CapturingMutator.scala
@@ -1,6 +1,6 @@
 package weaponregex.mutator
 
-import weaponregex.model.mutation.TokenMutator
+import weaponregex.model.mutation.{Mutant, TokenMutator}
 import weaponregex.model.regextree._
 
 /** Modify capturing group to non-capturing group
@@ -13,10 +13,10 @@ object GroupToNCGroup extends TokenMutator {
   override val levels: Seq[Int] = Seq(2, 3)
   override val description: String = "Modify capturing group to non-capturing group"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case group @ Group(_, true, _) => Seq(group.copy(isCapturing = false))
     case _                         => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantBeforeChildrenOf(token))
 }
 
 /** Negate lookaround (lookahead, lookbehind) constructs
@@ -29,8 +29,8 @@ object LookaroundNegation extends TokenMutator {
   override val levels: Seq[Int] = Seq(1, 2, 3)
   override val description: String = "Negate lookaround constructs (lookahead, lookbehind)"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case la: Lookaround => Seq(la.copy(isPositive = !la.isPositive))
     case _              => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantBeforeChildrenOf(token))
 }

--- a/core/src/main/scala/weaponregex/mutator/CharClassMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/CharClassMutator.scala
@@ -1,6 +1,6 @@
 package weaponregex.mutator
 
-import weaponregex.model.mutation.TokenMutator
+import weaponregex.model.mutation.{Mutant, TokenMutator}
 import weaponregex.model.regextree._
 
 /** Negate character class
@@ -13,10 +13,10 @@ object CharClassNegation extends TokenMutator {
   override val levels: Seq[Int] = Seq(1)
   override val description: String = "Negate character class"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case cc: CharacterClass => Seq(cc.copy(isPositive = !cc.isPositive))
     case _                  => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantBeforeChildrenOf(token))
 }
 
 /** Remove a child from character class
@@ -29,9 +29,10 @@ object CharClassChildRemoval extends TokenMutator {
   override val levels: Seq[Int] = Seq(2, 3)
   override val description: String = "Remove a child character class"
 
-  override def mutate(token: RegexTree): Seq[String] = token match {
-    case cc: CharacterClass if cc.children.length > 1 => cc.children map (child => cc.buildWhile(_ ne child))
-    case _                                            => Nil
+  override def mutate(token: RegexTree): Seq[Mutant] = token match {
+    case cc: CharacterClass if cc.children.length > 1 =>
+      cc.children map (child => cc.buildWhile(_ ne child).toMutantOf(child))
+    case _ => Nil
   }
 }
 
@@ -45,13 +46,13 @@ object CharClassAnyChar extends TokenMutator {
   override val levels: Seq[Int] = Seq(2, 3)
   override val description: String = "Change character class to match any character [\\w\\W]"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case cc: CharacterClass =>
       Seq(
         CharacterClass(Seq(PredefinedCharClass("w", cc.location), PredefinedCharClass("W", cc.location)), cc.location)
       )
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantOf(token))
 }
 
 /** Modify the range inside the character class by increasing or decreasing once
@@ -72,7 +73,7 @@ object CharClassRangeModification extends TokenMutator {
   // [a-a] -> [a-b]
   // [z-z] -> [y-z]
   // same for numbers
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case range @ Range(from: Character, to: Character, _) =>
       (from.char, to.char) match {
         case (l, r) if !(l.isDigit && r.isDigit) && !(l.isLetter && r.isLetter) => Nil
@@ -109,7 +110,7 @@ object CharClassRangeModification extends TokenMutator {
           )
       }
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantOf(token))
 
   /** Check if the given character is a left boundary character `0`, `a`, or `A`
     * @param char Character to be checked

--- a/core/src/main/scala/weaponregex/mutator/PredefCharClassMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/PredefCharClassMutator.scala
@@ -57,7 +57,7 @@ object PredefCharClassAnyChar extends TokenMutator {
 /** Negate POSIX character class
   *
   * ''Mutation level(s):'' 1
-  * @example `\d` ⟶ `\D`
+  * @example `\p{Alpha}` ⟶ `\P{Alpha}`
   */
 object POSIXCharClassNegation extends TokenMutator {
   override val name = "POSIX Character Class Negation"
@@ -67,5 +67,5 @@ object POSIXCharClassNegation extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case pcc: POSIXCharClass => Seq(pcc.copy(isPositive = !pcc.isPositive))
     case _                   => Nil
-  }) map (_.build.toMutantOf(token))
+  }) map (_.build.toMutantBeforeChildrenOf(token))
 }

--- a/core/src/main/scala/weaponregex/mutator/PredefCharClassMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/PredefCharClassMutator.scala
@@ -1,6 +1,6 @@
 package weaponregex.mutator
 
-import weaponregex.model.mutation.TokenMutator
+import weaponregex.model.mutation.{Mutant, TokenMutator}
 import weaponregex.model.regextree._
 import weaponregex.`extension`.StringExtension._
 
@@ -14,10 +14,10 @@ object PredefCharClassNegation extends TokenMutator {
   override val levels: Seq[Int] = Seq(1)
   override val description: String = "Negate predefined character class"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case pdcc: PredefinedCharClass => Seq(pdcc.copy(charClass = pdcc.charClass.toggleCase))
     case _                         => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantOf(token))
 }
 
 /** Nullify a predefined character class by removing the `\`
@@ -30,10 +30,10 @@ object PredefCharClassNullification extends TokenMutator {
   override val levels: Seq[Int] = Seq(2, 3)
   override val description: String = "Nullify a predefined character class by removing the `\\`"
 
-  override def mutate(token: RegexTree): Seq[String] = token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case pdcc: PredefinedCharClass => Seq(pdcc.charClass)
     case _                         => Nil
-  }
+  }) map (_.toMutantOf(token))
 }
 
 /** "Add the negation of that predefined character class to match any character `[\\w\\W]`"
@@ -47,11 +47,11 @@ object PredefCharClassAnyChar extends TokenMutator {
   override val description: String =
     "Add the negation of that predefined character class to match any character [\\w\\W]"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case pdcc: PredefinedCharClass =>
       Seq(CharacterClass(Seq(pdcc, pdcc.copy(charClass = pdcc.charClass.toggleCase)), pdcc.location))
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantOf(token))
 }
 
 /** Negate POSIX character class
@@ -64,8 +64,8 @@ object POSIXCharClassNegation extends TokenMutator {
   override val levels: Seq[Int] = Seq(1)
   override val description: String = "Negate POSIX character class"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case pcc: POSIXCharClass => Seq(pcc.copy(isPositive = !pcc.isPositive))
     case _                   => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantOf(token))
 }

--- a/core/src/main/scala/weaponregex/mutator/QuantifierMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/QuantifierMutator.scala
@@ -1,6 +1,6 @@
 package weaponregex.mutator
 
-import weaponregex.model.mutation.TokenMutator
+import weaponregex.model.mutation.{Mutant, TokenMutator}
 import weaponregex.model.regextree._
 
 /** Remove any type of quantifier including `?`, `*`, `+`, and `{n,m}`
@@ -14,19 +14,19 @@ object QuantifierRemoval extends TokenMutator {
   override val description: String =
     "Remove greedy, reluctant, and possessive quantifier including `?`, `*`, `+`, and `{n,m}`"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: ZeroOrOne  => Seq(q.expr)
     case q: ZeroOrMore => Seq(q.expr)
     case q: OneOrMore  => Seq(q.expr)
     case q: Quantifier => Seq(q.expr)
     case _             => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantAfterChildrenOf(token))
 }
 
 /** Change quantifier `{n}` to `{0,n}`, and `{n,}`
   *
   * ''Mutation level(s):'' 2, 3
-  * @example `a{5}` ⟶ `a{0,5}`, ``a{}5,
+  * @example `a{5}` ⟶ `a{0,5}`, `a{5,}`
   */
 object QuantifierNChange extends TokenMutator {
   override val name: String = "Quantifier `{n}` change"
@@ -34,14 +34,14 @@ object QuantifierNChange extends TokenMutator {
   override val description: String =
     "Change quantifier `{n}` to `{0,n}`, and `{n,}`"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: Quantifier if q.isExact =>
       Seq(
         q.copy(isExact = false, min = 0, max = q.min),
         q.copy(isExact = false, max = Quantifier.Infinity)
       )
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantAfterChildrenOf(token))
 }
 
 /** Modify quantifier `{n,}` to `{n-1,}`, and `{n+1,}`
@@ -55,12 +55,12 @@ object QuantifierNOrMoreModification extends TokenMutator {
   override val description: String =
     "Modify quantifier `{n,}` to `{n-1,}`, and `{n+1,}`"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: Quantifier if !q.isExact && q.max == Quantifier.Infinity =>
       if (q.min < 1) Seq(q.copy(min = q.min + 1))
       else Seq(q.copy(min = q.min - 1), q.copy(min = q.min + 1))
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantAfterChildrenOf(token))
 }
 
 /** Change quantifier `{n,}` to `{n}`
@@ -74,10 +74,10 @@ object QuantifierNOrMoreChange extends TokenMutator {
   override val description: String =
     "Change quantifier `{n,}` to `{n}`"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: Quantifier if !q.isExact && q.max == Quantifier.Infinity => Seq(q.copy(isExact = true))
     case _                                                           => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantAfterChildrenOf(token))
 }
 
 /** Modify quantifier `{n,m}` to `{n-1,m}`, `{n+1,m}`, `{n,m-1}`, and `{n,m+1}`
@@ -91,7 +91,7 @@ object QuantifierNMModification extends TokenMutator {
   override val description: String =
     "Modify quantifier `{n,m}` to `{n-1,m}`, `{n+1,m}`, `{n,m-1}`, and `{n,m+1}`"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: Quantifier if !q.isExact && q.max != Quantifier.Infinity =>
       (q.min, q.max) match {
         case (n, m) if n < 0 && m < 0 => Nil
@@ -106,7 +106,7 @@ object QuantifierNMModification extends TokenMutator {
           )
       }
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantAfterChildrenOf(token))
 }
 
 /** Modify quantifier `?`, `*`, `+` to `{n,}`, or `{n,m}`
@@ -120,7 +120,7 @@ object QuantifierShortModification extends TokenMutator {
   override val description: String =
     "Modify quantifier `?`, `*`, `+` to `{n,}`, or `{n,m}`"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: ZeroOrOne =>
       Seq(
         Quantifier(q.expr, min = 1, max = 1, q.location, q.quantifierType),
@@ -135,7 +135,7 @@ object QuantifierShortModification extends TokenMutator {
         Quantifier(q.expr, min = 2, max = Quantifier.Infinity, q.location, q.quantifierType)
       )
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantAfterChildrenOf(token))
 }
 
 /** Change quantifier `*`, `+` to `{n}`
@@ -149,13 +149,13 @@ object QuantifierShortChange extends TokenMutator {
   override val description: String =
     "Change quantifier `*`, `+` to `{n}`"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: ZeroOrMore =>
       Seq(Quantifier(q.expr, exact = 0, q.location, q.quantifierType))
     case q: OneOrMore =>
       Seq(Quantifier(q.expr, exact = 1, q.location, q.quantifierType))
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantAfterChildrenOf(token))
 }
 
 /** Add reluctant quantifier type to greedy quantifier
@@ -169,7 +169,7 @@ object QuantifierReluctantAddition extends TokenMutator {
   override val description: String =
     "Add reluctant quantifier type to greedy quantifier"
 
-  override def mutate(token: RegexTree): Seq[String] = (token match {
+  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: ZeroOrOne if q.quantifierType == GreedyQuantifier =>
       Seq(q.copy(quantifierType = ReluctantQuantifier))
     case q: ZeroOrMore if q.quantifierType == GreedyQuantifier =>
@@ -179,5 +179,5 @@ object QuantifierReluctantAddition extends TokenMutator {
     case q: Quantifier if q.quantifierType == GreedyQuantifier =>
       Seq(q.copy(quantifierType = ReluctantQuantifier))
     case _ => Nil
-  }) map (_.build)
+  }) map (_.build.toMutantAfterChildrenOf(token))
 }

--- a/core/src/main/scala/weaponregex/mutator/TreeMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/TreeMutator.scala
@@ -14,7 +14,7 @@ object TreeMutator {
       * @return Sequence of token mutators in the given mutation levels
       */
     private def filterMutators(mutators: Seq[TokenMutator], mutationLevels: Seq[Int]): Seq[TokenMutator] =
-      mutators.filter(mutator => mutationLevels.exists(mutator.levels.contains(_)))
+      mutators.filter(mutator => mutationLevels exists (mutator.levels contains _))
 
     /** Mutate using the given mutators in some specific mutation levels
       *
@@ -27,16 +27,10 @@ object TreeMutator {
         if (mutationLevels == null) mutators
         else filterMutators(mutators, mutationLevels)
 
-      val rootMutants: Seq[Mutant] = mutatorsFiltered flatMap (mutator =>
-        mutator(tree) map (mutatedPattern =>
-          Mutant(mutatedPattern, mutator.name, tree.location, mutator.levels, mutator.description)
-        )
-      )
+      val rootMutants: Seq[Mutant] = mutatorsFiltered flatMap (_(tree))
 
       val childrenMutants: Seq[Mutant] = tree.children flatMap (child =>
-        child.mutate(mutatorsFiltered) map { case mutant @ Mutant(mutatedPattern, _, _, _, _) =>
-          mutant.copy(pattern = tree.buildWith(child, mutatedPattern))
-        }
+        child.mutate(mutatorsFiltered) map (mutant => mutant.copy(pattern = tree.buildWith(child, mutant.pattern)))
       )
 
       rootMutants ++ childrenMutants

--- a/core/src/main/scalajs/weaponregex/model/mutation/TokenMutatorJS.scala
+++ b/core/src/main/scalajs/weaponregex/model/mutation/TokenMutatorJS.scala
@@ -28,13 +28,13 @@ case class TokenMutatorJS(tokenMutator: TokenMutator) {
 
   /** Apply mutation to the given token
     * @param token Target token
-    * @return Sequence of strings, which are mutations of the original token
+    * @return Sequence [[weaponregex.model.mutation.MutantJS]]
     */
-  final def apply(token: RegexTree): Seq[String] = mutate(token)
+  final def apply(token: RegexTree): Seq[MutantJS] = mutate(token)
 
   /** Mutate the given token
     * @param token Target token
-    * @return Sequence of strings, which are mutations of the original token
+    * @return Sequence of [[weaponregex.model.mutation.MutantJS]]
     */
-  def mutate(token: RegexTree): Seq[String] = tokenMutator.mutate(token)
+  def mutate(token: RegexTree): Seq[MutantJS] = tokenMutator.mutate(token) map MutantJS
 }


### PR DESCRIPTION
This PR changes the return type of token mutators from `String` to `Mutant`. By doing so, a token mutator now has more control over the information (e.g. location of the mutation, description, etc.) of each `Mutant` mutated by it.

This change means:
- **From the outside, `Weapon-regeX` should have NO behavioral difference.**
- Mutate/Apply a `RegexTree` to a `TokenMutator` now returns a sequence of `Mutant`. This is also the case, for `TokenMutatorJS` and `MutantJS`.
- All existing token mutators that are descendants of `TokenMutator` have been adapted to this change.
- Any user-define token mutator that is a descendant of `TokenMutator` needs to adapt to this change. ([👇 Guide](#Adapt-token-mutator-to-return-`Mutant`))
- `TreeMutator` now only traverses the tree, repacks `Mutant`s with (more) complete patterns, and not create entirely new `Mutant`s. New `Mutant`s are only created by the token mutators.

This PR also updates the existing token mutators to produce `Mutant`s with more precise mutation locations, enabled by the above change. ([👇 Mutation location changes](#Mutation-location-changes))

## Mutation location changes
### `BOLRemoval`
```scala
// Before
"^HelloWorld" -> "HelloWorld"
 └──────────┘
// After
"^HelloWorld" -> "HelloWorld"
 └┘
```

### `EOLRemoval`
```scala
// Before
"HelloWorld$" -> "HelloWorld"
 └──────────┘
// After
"HelloWorld$" -> "HelloWorld"
           └┘
```

### `GroupToNCGroup`
```scala
// Before
"(HelloWorld)" -> "(?:HelloWorld)"
 └───────────┘
// After
"(HelloWorld)" -> "(?:HelloWorld)"
 └┘
```

### `LookaroundNegation`
```scala
// Before
"(?=HelloWorld)"  <-> "(?!HelloWorld)"
 └─────────────┘       └─────────────┘
"(?<=HelloWorld)" <-> "(?<!HelloWorld)"
 └──────────────┘      └──────────────┘
// After
"(?=HelloWorld)"  <-> "(?!HelloWorld)"
 └──┘                  └──┘
"(?<=HelloWorld)" <-> "(?<!HelloWorld)"
 └───┘                 └───┘
```

### `CharClassNegation`
```scala
// Before
"[HelloWorld]" <-> "[^HelloWorld]"
 └───────────┘      └────────────┘
// After
"[HelloWorld]" <-> "[^HelloWorld]"
 └┘                 └─┘
```

### `CharClassChildRemoval`
```scala
// Before
"[HelloWorld]" -> "[HellWorld]"
 └───────────┘     └──────────┘
// After
"[HelloWorld]" -> "[HellWorld]"
      └┘
```

### `POSIXCharClassNegation`
```scala
// Before
"""\p{Alpha}""" <-> """\P{Alpha}"""
   └────────┘          └────────┘
// After
"""\p{Alpha}""" <-> """\P{Alpha}"""
   └──┘                └──┘
```

### `QuantifierRemoval`
```scala
// Before
"(HelloWorld)*" -> "(HelloWorld)"
 └────────────┘
// After
"(HelloWorld)*" -> "(HelloWorld)"
             └┘
```

### `QuantifierNChange`
```scala
// Before
"(HelloWorld){10}" -> "(HelloWorld){10,}", "(HelloWorld){0,10}"
 └───────────────┘
// After
"(HelloWorld){10}" -> "(HelloWorld){10,}", "(HelloWorld){0,10}"
             └───┘
```

### `QuantifierNOrMoreModification`
```scala
// Before
"(HelloWorld){10,}" -> "(HelloWorld){9,}", "(HelloWorld){11,}"
 └────────────────┘
// After
"(HelloWorld){10,}" -> "(HelloWorld){9,}", "(HelloWorld){11,}"
             └────┘
```

### `QuantifierNOrMoreChange`
```scala
// Before
"(HelloWorld){10,}" -> "(HelloWorld){10}"
 └────────────────┘
// After
"(HelloWorld){10,}" -> "(HelloWorld){10}"
             └────┘
```

### `QuantifierNMModification`
```scala
// Before
"(HelloWorld){10,20}" -> "(HelloWorld){9,20}", "(HelloWorld){11,20}",
 └──────────────────┘    "(HelloWorld){10,19}", "(HelloWorld){10,21}"
// After
"(HelloWorld){10,20}" -> "(HelloWorld){9,20}", "(HelloWorld){11,20}",
             └──────┘    "(HelloWorld){10,19}", "(HelloWorld){10,21}"
```

### `QuantifierShortModification`
```scala
// Before
"(HelloWorld)*" -> "(HelloWorld){0,0}", "(HelloWorld){0,2}",
 └────────────┘    "(HelloWorld){1,1}"
// After
"(HelloWorld)*" -> "(HelloWorld){9,20}", "(HelloWorld){11,20}",
             └┘    "(HelloWorld){10,19}", "(HelloWorld){10,21}"
```

### `QuantifierShortChange`
```scala
// Before
"(HelloWorld)*" -> "(HelloWorld){0}"
 └────────────┘
// After
"(HelloWorld)*" -> "(HelloWorld){0}"
             └┘
```

### `QuantifierReluctantAddition`
```scala
// Before
"(HelloWorld)+" -> "(HelloWorld)+?"
 └────────────┘
// After
"(HelloWorld)+" -> "(HelloWorld)+?"
             └┘
```

## Adapt token mutator to return `Mutant`
Due to the return type of token mutators change from `String` to `Mutant`, any token mutator that is a descendant of `TokenMutator` needs to adapt to this. 

This PR also provides some helper functions to make this adaptation easier. These are extension methods that convert a `String` into a `Mutant` **within the scope of each `TokenMutator`** by filling in the `Mutant` data with the information from the containing `TokenMutator`.
- Convert a mutated pattern string into a `Mutant` at the provided location.
```scala
"Pattern".toMutantAt(loc: Location)
```
- Convert a mutated pattern string into a `Mutant` with the location taken from the provided token.
```scala
"Pattern".toMutantOf(token: RegexTree)
```
- Convert a mutated pattern string into a `Mutant` with the location starts from the start of the provided token and ends at the start of the token's first child. <sup>(*)</sup>
  - *Sample results:* [`GroupToNCGroup`](#`GroupToNCGroup`), [`LookaroundNegation`](#`LookaroundNegation`), [`CharClassNegation`](#`CharClassNegation`), [`POSIXCharClassNegation`](#`POSIXCharClassNegation`)
```scala
"Pattern".toMutantBeforeChildrenOf(token: RegexTree)
```
- Convert a mutated pattern string into a `Mutant` with the location starts from the end of the provided token's last child and ends at the end of the token. <sup>(*)</sup>
  - *Sample results:* [`QuantifierNChange`](#`QuantifierNChange`), [`QuantifierNOrMoreModification`](#`QuantifierNOrMoreModification`), [`QuantifierNOrMoreChange`](#`QuantifierNOrMoreChange`), [`QuantifierNMModification`](#`QuantifierNMModification`), [`QuantifierShortModification`](#`QuantifierShortModification`), [`QuantifierShortChange`](#`QuantifierShortChange`), [`QuantifierReluctantAddition`](#`QuantifierReluctantAddition`)
```scala
"Pattern".toMutantAfterChildrenOf(token: RegexTree)
```

<sup>(*) If the given token has no child, the location of the given token is considered to be the location of the mutant</sup>

### Example
Here is an example of a simple case of adaptation. This will produce the same `Mutant`s as before this PR.

```scala
// Before
object PredefCharClassNegation extends TokenMutator {
  // ...
  override def mutate(token: RegexTree): Seq[String] = (token match {
    case pdcc: PredefinedCharClass =>
      Seq(pdcc.copy(charClass = pdcc.charClass.toggleCase))
    case _ => Nil
  }) map (_.build)
}

// After
object PredefCharClassNegation extends TokenMutator {
  // ...
  override def mutate(token: RegexTree): Seq[Mutant] = (token match {
    case pdcc: PredefinedCharClass =>
      Seq(pdcc.copy(charClass = pdcc.charClass.toggleCase))
    case _ => Nil
  }) map (_.build.toMutantOf(token)) // Convert into `Mutant`
}
```
*See the file changes of this PR for more examples.*