### PR TITLE
Long quantifier limits check + unparsable with nothing preceding

### DIFF
--- a/core/src/main/scala/weaponregex/mutator/QuantifierMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/QuantifierMutator.scala
@@ -94,9 +94,14 @@ object QuantifierNMModification extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: Quantifier if !q.isExact && q.max != Quantifier.Infinity =>
       (q.min, q.max) match {
-        case (n, m) if n < 0 && m < 0 => Nil
-        case (0, 0)                   => Seq(q.copy(max = 1))
-        case (0, m)                   => Seq(q.copy(min = 1), q.copy(max = m - 1), q.copy(max = m + 1))
+        case (0, 0) =>
+          Seq(q.copy(max = 1))
+        case (0, m) =>
+          Seq(
+            q.copy(min = 1),
+            q.copy(max = m - 1),
+            q.copy(max = m + 1)
+          )
         case (n, m) =>
           Seq(
             q.copy(min = n - 1),

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -66,13 +66,19 @@ abstract class Parser(val pattern: String) {
     */
   def number[_: P]: P[Int] = P(CharIn("0-9").rep(1).!) map (_.toInt)
 
+  /** Parse special cases of a character literal
+    * @return The captured character as a string
+    */
+  def charLiteralSpecialCases[_: P]: P[String] = Fail
+
   /** Parse a single literal character that is not a regex special character
     * @return [[weaponregex.model.regextree.Character]] tree node
     * @example `"a"`
     * @see [[weaponregex.parser.Parser.specialChars]]
     */
-  def charLiteral[_: P]: P[Character] = Indexed(CharPred(!specialChars.contains(_)).!)
-    .map { case (loc, c) => Character(c.head, loc) }
+  def charLiteral[_: P]: P[Character] =
+    Indexed(CharPred(!specialChars.contains(_)).! | charLiteralSpecialCases)
+      .map { case (loc, c) => Character(c.head, loc) }
 
   /** Intermediate parsing rule for character-related tokens which can parse either `metaCharacter` or `charLiteral`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree
@@ -163,13 +169,19 @@ abstract class Parser(val pattern: String) {
   def range[_: P]: P[Range] = Indexed(charClassCharLiteral ~ "-" ~ charClassCharLiteral)
     .map { case (loc, (from, to)) => Range(from, to, loc) }
 
+  /** Parse special cases of a character literal in a character class
+    * @return The captured character as a string
+    */
+  def charClassCharLiteralSpecialCases[_: P]: P[String] = Fail
+
   /** Parse a single literal character that is allowed to be in a character class
     * @return [[weaponregex.model.regextree.Character]] tree node
     * @example `"{"`
     * @see [[weaponregex.parser.Parser.charClassSpecialChars]]
     */
-  def charClassCharLiteral[_: P]: P[Character] = Indexed(CharPred(!charClassSpecialChars.contains(_)).!)
-    .map { case (loc, c) => Character(c.head, loc) }
+  def charClassCharLiteral[_: P]: P[Character] =
+    Indexed(CharPred(!charClassSpecialChars.contains(_)).! | charClassCharLiteralSpecialCases)
+      .map { case (loc, c) => Character(c.head, loc) }
 
   /** Intermediate parsing rule for character class item tokens which can parse either
     * `charClass`, `preDefinedCharClass`, `metaCharacter`, `range`, `quoteChar`, or `charClassCharLiteral`
@@ -240,13 +252,22 @@ abstract class Parser(val pattern: String) {
       }
     }
 
+  /** Parse the tail part of a long quantifier
+    * @return A tuple of the quantifier minimum and optional maximum part
+    */
+  def quantifierLongTail[_: P]: P[(Int, Option[Option[Int]])] = number ~ ("," ~ number.?).? ~ "}"
+
   /** Parse a (full) quantifier (`{n}`, `{n,}`, `{n,m}`)
     * @return [[weaponregex.model.regextree.Quantifier]] tree node
     * @example `"a{1}"`
     */
   def quantifierLong[_: P]: P[Quantifier] =
-    Indexed(quantifierType(elementaryRE ~ "{" ~ number ~ ("," ~ number.?).? ~ "}"))
-      .map { case (loc, ((expr, num, optionMax), quantifierType)) =>
+    Indexed(quantifierType(elementaryRE ~ "{" ~ quantifierLongTail))
+      .filter {
+        case (_, ((_, (min, Some(Some(max)))), _)) => min <= max
+        case _                                     => true
+      }
+      .map { case (loc, ((expr, (num, optionMax)), quantifierType)) =>
         optionMax match {
           case None            => Quantifier(expr, num, loc, quantifierType)
           case Some(None)      => Quantifier(expr, num, Quantifier.Infinity, loc, quantifierType)

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -261,6 +261,8 @@ abstract class Parser(val pattern: String) {
     * @return [[weaponregex.model.regextree.Quantifier]] tree node
     * @example `"a{1}"`
     */
+  // `.filter()` function from fastparse is wrongly mutated by Stryker4s into `.filterNot()` which does not exist in fastparse
+  @SuppressWarnings(Array("stryker4s.mutation.MethodExpression"))
   def quantifierLong[_: P]: P[Quantifier] =
     Indexed(quantifierType(elementaryRE ~ "{" ~ quantifierLongTail))
       .filter {

--- a/core/src/main/scala/weaponregex/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJS.scala
@@ -13,7 +13,7 @@ class ParserJS private[parser] (pattern: String) extends Parser(pattern) {
 
   /** Regex special characters
     */
-  override val specialChars: String = """()[\.^$|?*+"""
+  override val specialChars: String = """()[{\.^$|?*+"""
 
   /** Special characters within a character class
     */
@@ -34,6 +34,11 @@ class ParserJS private[parser] (pattern: String) extends Parser(pattern) {
   /** Minimum number of character class items of a valid character class
     */
   override val minCharClassItem: Int = 0
+
+  /** Parse special cases of a character literal
+    * @return The captured character as a string
+    */
+  override def charLiteralSpecialCases[_: P]: P[String] = P("{".! ~ !quantifierLongTail)
 
   /** Intermediate parsing rule for character class item tokens which can parse either `preDefinedCharClass`, `metaCharacter`, `range`, `quoteChar`, or `charClassCharLiteral`
     * @return [[weaponregex.model.regextree.RegexTree]] (sub)tree

--- a/core/src/main/scala/weaponregex/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJVM.scala
@@ -6,7 +6,6 @@ import weaponregex.model.regextree.{MetaChar, RegexTree}
 import weaponregex.model.regextree.CharacterClass
 import weaponregex.model.regextree.CharClassIntersection
 import weaponregex.model.regextree.CharacterClassNaked
-import weaponregex.model.regextree.Character
 
 /** Concrete parser for JVM flavor of regex
   * @param pattern The regex pattern to be parsed

--- a/core/src/main/scala/weaponregex/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJVM.scala
@@ -48,14 +48,10 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
     Indexed("""\0""" ~ (CharIn("0-3") ~ CharIn("0-7").rep(exactly = 2) | CharIn("0-7").rep(min = 1, max = 2)).!)
       .map { case (loc, octDigits) => MetaChar("0" + octDigits, loc) }
 
-  /** Parse a single literal character that is allowed to be in a character class
-    * @return [[weaponregex.model.regextree.Character]] tree node
-    * @example `"{"`
-    * @see [[weaponregex.parser.Parser.charClassSpecialChars]]
+  /** Parse special cases of a character literal in a character class
+    * @return The captured character as a string
     */
-  override def charClassCharLiteral[_: P]: P[Character] =
-    Indexed(CharPred(!charClassSpecialChars.contains(_)).! | "&".! ~ !"&")
-      .map { case (loc, c) => Character(c.head, loc) }
+  override def charClassCharLiteralSpecialCases[_: P]: P[String] = P("&".! ~ !"&")
 
   /** Parse a character class content without the surround syntactical symbols, i.e. "naked"
     * @return [[weaponregex.model.regextree.CharacterClassNaked]] tree node

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -569,6 +569,20 @@ class ParserJSTest extends ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Unparsable: long quantifier with min > max") {
+    val pattern = "a{2,1}"
+    parseErrorTest(pattern)
+  }
+
+  test("Unparsable: long-quantifier-like with nothing preceding") {
+    val patterns = Seq(
+      "{1}",
+      "{1,}",
+      "{1,2}"
+    )
+    patterns map parseErrorTest
+  }
+
   test("Parse capturing group") {
     val pattern = "(hello)(world)"
     val parsedTree = Parser(pattern, parserFlavor).get

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -596,6 +596,11 @@ class ParserJVMTest extends ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Unparsable: long quantifier with min > max") {
+    val pattern = "a{2,1}"
+    parseErrorTest(pattern)
+  }
+
   test("Parse capturing group") {
     val pattern = "(hello)(world)"
     val parsedTree = Parser(pattern, parserFlavor).get


### PR DESCRIPTION
+ Add check in the `quantifierLong` for valid limits (min <= max) + tests. The following string(s) will now be unparsable:
```scala
"anything{2,1}" // min > max
```
+ [JS] Fix long-quantifier-like string with nothing preceding should not be parsable (as characters) + test. The following string(s) will now be unparsable:
```scala
"{1}"
"{1,}"
"{1,2}"
```
These are still parsable
```scala
"(){1}" // long quantifier of a group of nothing
"{}"    // as 2 characters `{` and `}`
"{-1}"  // as 4 characters `{`, `-`, `1`, and `}`
```