### PR TITLE
Remove scala 2.12 for JS platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val WeaponRegeX = projectMatrix
     )
   )
   .jsPlatform(
-    scalaVersions = List(Scala213, Scala212),
+    scalaVersions = List(Scala213),
     settings = Seq(
       // Add JS-specific settings here
       scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))


### PR DESCRIPTION
- Remove scala 2.12 for JS platform since it adds no extra value when converted to JS and only the generated JS code from scala 2.13 is released to `npm` anyway