### PR TITLE
`TreeMutator` should only filter the input token mutators once

### DIFF
--- a/core/src/main/scala/weaponregex/extension/TokenMutatorExtension.scala
+++ b/core/src/main/scala/weaponregex/extension/TokenMutatorExtension.scala
@@ -1,0 +1,22 @@
+package weaponregex.extension
+
+import weaponregex.model.mutation.TokenMutator
+
+object TokenMutatorExtension {
+  implicit class TokenMutatorsFiltering(mutators: Seq[TokenMutator]) {
+
+    /** Filter token mutators based on the given mutation level
+      * @param mutationLevel Target mutation level
+      * @return Sequence of token mutators in the given mutation levels
+      */
+    def atLevel(mutationLevel: Int): Seq[TokenMutator] =
+      mutators filter (_.levels.contains(mutationLevel))
+
+    /** Filter token mutators based on the given mutation levels
+      * @param mutationLevels Target mutation levels
+      * @return Sequence of token mutators in the given mutation levels
+      */
+    def atLevels(mutationLevels: Seq[Int]): Seq[TokenMutator] =
+      mutators filter (mutator => mutationLevels exists (mutator.levels contains _))
+  }
+}

--- a/core/src/main/scala/weaponregex/mutator/TreeMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/TreeMutator.scala
@@ -2,19 +2,12 @@ package weaponregex.mutator
 
 import weaponregex.model.mutation.{Mutant, TokenMutator}
 import weaponregex.model.regextree.RegexTree
+import weaponregex.`extension`.TokenMutatorExtension.TokenMutatorsFiltering
 
 /** The object that traverses and mutates a given [[weaponregex.model.regextree.RegexTree]]
   */
 object TreeMutator {
   implicit class RegexTreeMutator(tree: RegexTree) {
-
-    /** Filter token mutators based on the given mutation levels
-      * @param mutators Token mutators to be filtered
-      * @param mutationLevels Target mutation levels
-      * @return Sequence of token mutators in the given mutation levels
-      */
-    private def filterMutators(mutators: Seq[TokenMutator], mutationLevels: Seq[Int]): Seq[TokenMutator] =
-      mutators.filter(mutator => mutationLevels exists (mutator.levels contains _))
 
     /** Mutate using the given mutators in some specific mutation levels
       *
@@ -22,17 +15,22 @@ object TreeMutator {
       * @param mutationLevels Target mutation levels. If this is `null`, the `mutators` will not be filtered.
       * @return A sequence of [[weaponregex.model.mutation.Mutant]]
       */
-    def mutate(mutators: Seq[TokenMutator] = BuiltinMutators.all, mutationLevels: Seq[Int] = null): Seq[Mutant] = {
-      val mutatorsFiltered: Seq[TokenMutator] =
+    def mutate(mutators: Seq[TokenMutator] = BuiltinMutators.all, mutationLevels: Seq[Int] = null): Seq[Mutant] =
+      mutate(
         if (mutationLevels == null) mutators
-        else filterMutators(mutators, mutationLevels)
-
-      val rootMutants: Seq[Mutant] = mutatorsFiltered flatMap (_(tree))
-
-      val childrenMutants: Seq[Mutant] = tree.children flatMap (child =>
-        child.mutate(mutatorsFiltered) map (mutant => mutant.copy(pattern = tree.buildWith(child, mutant.pattern)))
+        else mutators.atLevels(mutationLevels)
       )
 
+    /** Mutate using the given mutators
+      *
+      * @param mutators Mutators to be used for mutation
+      * @return A sequence of [[weaponregex.model.mutation.Mutant]]
+      */
+    private def mutate(mutators: Seq[TokenMutator]): Seq[Mutant] = {
+      val rootMutants: Seq[Mutant] = mutators flatMap (_(tree))
+      val childrenMutants: Seq[Mutant] = tree.children flatMap (child =>
+        child.mutate(mutators) map (mutant => mutant.copy(pattern = tree.buildWith(child, mutant.pattern)))
+      )
       rootMutants ++ childrenMutants
     }
   }

--- a/core/src/test/scala/weaponregex/extension/TokenMutatorExtensionTest.scala
+++ b/core/src/test/scala/weaponregex/extension/TokenMutatorExtensionTest.scala
@@ -1,0 +1,40 @@
+package weaponregex.extension
+
+import weaponregex.extension.TokenMutatorExtension.TokenMutatorsFiltering
+import weaponregex.mutator.BuiltinMutators
+
+class TokenMutatorExtensionTest extends munit.FunSuite {
+  test("Filter a single level") {
+    val level = 1
+    val mutators = BuiltinMutators.all.atLevel(level)
+    mutators foreach (mutator => assert(clue(mutator).levels contains level))
+  }
+
+  test("Filter a single non-existed level") {
+    val level = -1
+    val mutators = BuiltinMutators.all.atLevel(level)
+    assert(clue(mutators) == Nil)
+  }
+
+  test("Filter multiple levels") {
+    val levels = Seq(1, 2, 3)
+    val mutators = BuiltinMutators.all.atLevels(levels)
+    mutators foreach (mutator => assert(levels exists (clue(mutator).levels contains _)))
+  }
+
+  test("Filter multiple levels with some non-existed levels") {
+    val levels = Seq(1, 2, 3)
+    val badLevels = Seq(-1, -2, -3)
+    val mutators = BuiltinMutators.all.atLevels(levels ++ badLevels)
+    mutators foreach (mutator => {
+      assert(levels exists (clue(mutator).levels contains _))
+      assert(!(badLevels exists (clue(mutator).levels contains _)))
+    })
+  }
+
+  test("Filter non-existed multiple levels") {
+    val levels = Seq(-1, -2, -3)
+    val mutators = BuiltinMutators.all.atLevels(levels)
+    assert(clue(mutators) == Nil)
+  }
+}


### PR DESCRIPTION
+ Fix `TreeMutator` should only filter the input token mutators once, instead of on every `regexTree.mutate()` call
+ Move token mutators filtering to `TokenMutatorExtension.TokenMutatorsFiltering`
+ Add tests for `TokenMutatorExtension.TokenMutatorsFiltering`