### PR TITLE
feat: move node-only properties to Node

### DIFF
--- a/core/src/main/scala/weaponregex/extension/RegexTreeExtension.scala
+++ b/core/src/main/scala/weaponregex/extension/RegexTreeExtension.scala
@@ -11,11 +11,6 @@ object RegexTreeExtension {
     */
   implicit class RegexTreeStringBuilder(tree: RegexTree) {
 
-    protected def separator: String = tree match {
-      case node: Node => node.sep
-      case _: Leaf[_] => ""
-    }
-
     /** Build the tree into a String
       */
     lazy val build: String = tree match {
@@ -36,7 +31,7 @@ object RegexTreeExtension {
       case node: Node =>
         node.children
           .map(c => if (c eq child) childString else c.build)
-          .mkString(tree.prefix, tree.separator, tree.postfix)
+          .mkString(node.prefix, node.sep, tree.postfix)
       case _ => build
     }
 
@@ -51,7 +46,7 @@ object RegexTreeExtension {
         node.children
           .filter(pred)
           .map(_.build)
-          .mkString(tree.prefix, tree.separator, tree.postfix)
+          .mkString(tree.prefix, node.sep, tree.postfix)
       case _ => build
     }
   }

--- a/core/src/main/scala/weaponregex/model/mutation/TokenMutator.scala
+++ b/core/src/main/scala/weaponregex/model/mutation/TokenMutator.scala
@@ -2,6 +2,7 @@ package weaponregex.model.mutation
 
 import weaponregex.model.Location
 import weaponregex.model.regextree.RegexTree
+import weaponregex.model.regextree.Node
 
 trait TokenMutator {
 
@@ -70,9 +71,10 @@ trait TokenMutator {
       *   A [[weaponregex.model.mutation.Mutant]]
       */
     def toMutantBeforeChildrenOf(token: RegexTree): Mutant = {
-      val loc: Location =
-        if (token.children.isEmpty) token.location
-        else Location(token.location.start, token.children.head.location.start)
+      val loc: Location = token match {
+        case node: Node if node.children.nonEmpty => Location(token.location.start, node.children.head.location.start)
+        case _                                    => token.location
+      }
       toMutantAt(loc)
     }
 
@@ -87,9 +89,11 @@ trait TokenMutator {
       *   A [[weaponregex.model.mutation.Mutant]]
       */
     def toMutantAfterChildrenOf(token: RegexTree): Mutant = {
-      val loc: Location =
-        if (token.children.isEmpty) token.location
-        else Location(token.children.last.location.end, token.location.end)
+      val loc: Location = token match {
+        case node: Node if node.children.nonEmpty => Location(node.children.last.location.end, token.location.end)
+        case _                                    => token.location
+      }
+
       toMutantAt(loc)
     }
   }

--- a/core/src/main/scala/weaponregex/model/regextree/Leaf.scala
+++ b/core/src/main/scala/weaponregex/model/regextree/Leaf.scala
@@ -2,32 +2,6 @@ package weaponregex.model.regextree
 
 import weaponregex.model.Location
 
-/** The leaf of the [[weaponregex.model.regextree.RegexTree]] (terminal node) that have no children node
-  * @param value
-  *   The value that the leaf holds
-  * @param location
-  *   The [[weaponregex.model.Location]] of the node in the regex string
-  * @param prefix
-  *   The string that is put in front of the leaf's value when building
-  * @param postfix
-  *   The string that is put after the leaf's value when building
-  */
-abstract class Leaf[A](
-    val value: A,
-    override val location: Location,
-    override val prefix: String = "",
-    override val postfix: String = ""
-) extends RegexTree {
-
-  /** Since leaves have no children, this is always empty
-    */
-  final override val children: Seq[RegexTree] = Nil
-
-  /** Since leaves have no children, this is always an empty string
-    */
-  final override val sep: String = ""
-}
-
 /** Character literal leaf node
   * @param char
   *   The character literal value

--- a/core/src/main/scala/weaponregex/model/regextree/Node.scala
+++ b/core/src/main/scala/weaponregex/model/regextree/Node.scala
@@ -2,26 +2,6 @@ package weaponregex.model.regextree
 
 import weaponregex.model.Location
 
-/** The non-terminal node of the [[weaponregex.model.regextree.RegexTree]] that have at least one child node
-  * @param children
-  *   The children that fall under this node
-  * @param location
-  *   The [[weaponregex.model.Location]] of the node in the regex string
-  * @param prefix
-  *   The string that is put in front of the node's children when building
-  * @param postfix
-  *   The string that is put after the node's children when building
-  * @param sep
-  *   The string that is put in between the node's children when building
-  */
-abstract class Node(
-    override val children: Seq[RegexTree],
-    override val location: Location,
-    override val prefix: String = "",
-    override val postfix: String = "",
-    override val sep: String = ""
-) extends RegexTree
-
 /** Character class node
   * @param nodes
   *   The child nodes contained in the character class

--- a/core/src/main/scala/weaponregex/model/regextree/RegexTree.scala
+++ b/core/src/main/scala/weaponregex/model/regextree/RegexTree.scala
@@ -4,25 +4,54 @@ import weaponregex.model.Location
 
 /** The abstraction of a RegexTree node
   */
-trait RegexTree {
-
-  /** The children that fall under this node
-    */
-  val children: Seq[RegexTree]
+sealed trait RegexTree {
 
   /** The string that is put in front of the node's children when building
     */
-  val prefix: String
+  def prefix: String
 
   /** The string that is put after the node's children when building
     */
-  val postfix: String
-
-  /** The string that is put in between the node's children when building
-    */
-  val sep: String
+  def postfix: String
 
   /** The [[weaponregex.model.Location]] of the node in the regex string
     */
-  val location: Location
+  def location: Location
 }
+
+/** The non-terminal node of the [[weaponregex.model.regextree.RegexTree]] that have at least one child node
+  * @param children
+  *   The children that fall under this node
+  * @param location
+  *   The [[weaponregex.model.Location]] of the node in the regex string
+  * @param prefix
+  *   The string that is put in front of the node's children when building
+  * @param postfix
+  *   The string that is put after the node's children when building
+  * @param sep
+  *   The string that is put in between the node's children when building
+  */
+abstract class Node(
+    val children: Seq[RegexTree],
+    override val location: Location,
+    override val prefix: String = "",
+    override val postfix: String = "",
+    val sep: String = ""
+) extends RegexTree
+
+/** The leaf of the [[weaponregex.model.regextree.RegexTree]] (terminal node) that have no children node
+  * @param value
+  *   The value that the leaf holds
+  * @param location
+  *   The [[weaponregex.model.Location]] of the node in the regex string
+  * @param prefix
+  *   The string that is put in front of the leaf's value when building
+  * @param postfix
+  *   The string that is put after the leaf's value when building
+  */
+abstract class Leaf[A](
+    val value: A,
+    override val location: Location,
+    override val prefix: String = "",
+    override val postfix: String = ""
+) extends RegexTree

--- a/core/src/main/scala/weaponregex/mutator/BoundaryMutator.scala
+++ b/core/src/main/scala/weaponregex/mutator/BoundaryMutator.scala
@@ -15,9 +15,13 @@ object BOLRemoval extends TokenMutator {
   override val levels: Seq[Int] = Seq(1, 2, 3)
   override val description: String = "Remove beginning of line character `^`"
 
-  override def mutate(token: RegexTree): Seq[Mutant] = token.children flatMap {
-    case child: BOL => Seq(token.buildWhile(_ ne child).toMutantOf(child))
-    case _          => Nil
+  override def mutate(token: RegexTree): Seq[Mutant] = token match {
+    case node: Node =>
+      node.children flatMap {
+        case child: BOL => Seq(token.buildWhile(_ ne child).toMutantOf(child))
+        case _          => Nil
+      }
+    case _ => Nil
   }
 }
 
@@ -32,9 +36,13 @@ object EOLRemoval extends TokenMutator {
   override val levels: Seq[Int] = Seq(1, 2, 3)
   override val description: String = "Remove end of line character `$`"
 
-  override def mutate(token: RegexTree): Seq[Mutant] = token.children flatMap {
-    case child: EOL => Seq(token.buildWhile(_ ne child).toMutantOf(child))
-    case _          => Nil
+  override def mutate(token: RegexTree): Seq[Mutant] = token match {
+    case node: Node =>
+      node.children flatMap {
+        case child: EOL => Seq(token.buildWhile(_ ne child).toMutantOf(child))
+        case _          => Nil
+      }
+    case _ => Nil
   }
 }
 

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -15,19 +15,17 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Not parse `\A\G\z\Z` as boundary metacharacters""") {
     val pattern = """\A\G\z\Z"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Node]
 
-    assert(clue(parsedTree).isInstanceOf[Concat])
-    parsedTree.asInstanceOf[Node].children foreach (child => assert(!clue(child).isInstanceOf[Boundary]))
+    parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[Boundary]))
 
     treeBuildTest(parsedTree, pattern)
   }
 
   test("Parse empty positive character class with characters") {
     val pattern = "[]"
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
 
-    assert(clue(parsedTree).isInstanceOf[CharacterClass])
     assert(clue(parsedTree.children).isEmpty)
 
     treeBuildTest(parsedTree, pattern)
@@ -35,12 +33,9 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse negative character class with characters") {
     val pattern = "[^]"
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
 
-    assert(parsedTree match {
-      case CharacterClass(_, _, false) => true
-      case _                           => false
-    })
+    assert(!parsedTree.isPositive)
     assert(clue(parsedTree.children).isEmpty)
 
     treeBuildTest(parsedTree, pattern)
@@ -48,9 +43,8 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `[` as character inside a character class") {
     val pattern = "[[]"
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
 
-    assert(clue(parsedTree).isInstanceOf[CharacterClass])
     assert(clue(parsedTree.children.head) match {
       case Character('[', _) => true
       case _                 => false
@@ -61,9 +55,8 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Not parse `\a\e` as escape characters""") {
     val pattern = """\a\e"""
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
 
-    assert(clue(parsedTree).isInstanceOf[Concat])
     parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[MetaChar]))
 
     treeBuildTest(parsedTree, pattern)
@@ -71,7 +64,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse \\x{20} as quantifier") {
     val pattern = "\\x{20}"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Quantifier]
 
     assert(clue(parsedTree) match {
       case Quantifier(QuoteChar('x', _), 20, 20, _, GreedyQuantifier, true) => true
@@ -83,9 +76,8 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Not parse `\h\H\V` as predefined character class""") {
     val pattern = """\h\H\V"""
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
 
-    assert(clue(parsedTree).isInstanceOf[Concat])
     parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[PredefinedCharClass]))
 
     treeBuildTest(parsedTree, pattern)
@@ -148,9 +140,8 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Parse `\Q\E` as character quotes""") {
     val pattern = """stuff\Q$hit\Emorestuff"""
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
 
-    assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {
       case QuoteChar('Q', _) => true
       case _                 => false
@@ -165,9 +156,8 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Parse `\Q` as a character quote""") {
     val pattern = """stuff\Q$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
 
-    assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {
       case QuoteChar('Q', _) => true
       case _                 => false
@@ -187,11 +177,8 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `{`") {
     val pattern = "{"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Character]
 
-    assert(clue(parsedTree) match {
-      case Character('{', _) => true
-      case _                 => false
-    })
+    assertEquals(parsedTree.char, '{')
   }
 }

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -2,7 +2,7 @@ package weaponregex.parser
 
 import weaponregex.model.regextree._
 
-class ParserJSTest extends ParserTest {
+class ParserJSTest extends munit.FunSuite with ParserTest {
   final val parserFlavor: ParserFlavor = ParserFlavorJS
 
   val boundaryMetacharacters: String = """\b\B"""
@@ -18,14 +18,14 @@ class ParserJSTest extends ParserTest {
     val parsedTree = Parser(pattern, parserFlavor).get
 
     assert(clue(parsedTree).isInstanceOf[Concat])
-    parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[Boundary]))
+    parsedTree.asInstanceOf[Node].children foreach (child => assert(!clue(child).isInstanceOf[Boundary]))
 
     treeBuildTest(parsedTree, pattern)
   }
 
   test("Parse empty positive character class with characters") {
     val pattern = "[]"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     assert(clue(parsedTree.children).isEmpty)
@@ -35,7 +35,7 @@ class ParserJSTest extends ParserTest {
 
   test("Parse negative character class with characters") {
     val pattern = "[^]"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
 
     assert(parsedTree match {
       case CharacterClass(_, _, false) => true
@@ -48,7 +48,7 @@ class ParserJSTest extends ParserTest {
 
   test("Parse `[` as character inside a character class") {
     val pattern = "[[]"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     assert(clue(parsedTree.children.head) match {
@@ -61,7 +61,7 @@ class ParserJSTest extends ParserTest {
 
   test("""Not parse `\a\e` as escape characters""") {
     val pattern = """\a\e"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[MetaChar]))
@@ -83,7 +83,7 @@ class ParserJSTest extends ParserTest {
 
   test("""Not parse `\h\H\V` as predefined character class""") {
     val pattern = """\h\H\V"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[PredefinedCharClass]))
@@ -148,7 +148,7 @@ class ParserJSTest extends ParserTest {
 
   test("""Parse `\Q\E` as character quotes""") {
     val pattern = """stuff\Q$hit\Emorestuff"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {
@@ -165,7 +165,7 @@ class ParserJSTest extends ParserTest {
 
   test("""Parse `\Q` as a character quote""") {
     val pattern = """stuff\Q$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
 
     assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -25,7 +25,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse character class with nested character classes") {
     val pattern = "[[a-z][^A-Z0-9][01234]]"
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
 
     parsedTree.children foreach (child => assert(child.isInstanceOf[CharacterClass], clue = parsedTree.children))
 
@@ -35,12 +35,12 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
   test("Parse character class with simple intersection") {
     val subClasses = Seq("abc", "def", "ghi")
     val pattern = subClasses.mkString("[", "&&", "]")
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Node]
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     assertEquals(parsedTree.children.length, 1)
 
-    val intersection = parsedTree.children.head.asInstanceOf[CharClassIntersection]
+    val intersection = parsedTree.children.head.to[CharClassIntersection]
     assertEquals(intersection.children.length, 3)
     (subClasses zip intersection.children) foreach { case (str, child) =>
       assert(clue(child) match {
@@ -260,19 +260,16 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse numbered reference") {
     val pattern = """\123"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.to[NumberReference]
 
-    assert(clue(parsedTree) match {
-      case NumberReference(123, _) => true
-      case _                       => false
-    })
+    assertEquals(parsedTree.num, 123)
 
     treeBuildTest(parsedTree, pattern)
   }
 
   test("Parse long quote with end") {
     val pattern = """stuff\Q$hit\Emorestuff"""
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case Quote("$hit", true, _) => true
@@ -284,7 +281,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse long quote without end") {
     val pattern = """stuff\Q$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case Quote("$hit", false, _) => true

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -2,7 +2,7 @@ package weaponregex.parser
 
 import weaponregex.model.regextree._
 
-class ParserJVMTest extends ParserTest {
+class ParserJVMTest extends munit.FunSuite with ParserTest {
   final val parserFlavor: ParserFlavor = ParserFlavorJVM
 
   val boundaryMetacharacters: String = """\b\B\A\G\z\Z"""
@@ -25,9 +25,8 @@ class ParserJVMTest extends ParserTest {
 
   test("Parse character class with nested character classes") {
     val pattern = "[[a-z][^A-Z0-9][01234]]"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[CharacterClass]
 
-    assert(clue(parsedTree).isInstanceOf[CharacterClass])
     parsedTree.children foreach (child => assert(child.isInstanceOf[CharacterClass], clue = parsedTree.children))
 
     treeBuildTest(parsedTree, pattern)
@@ -36,13 +35,12 @@ class ParserJVMTest extends ParserTest {
   test("Parse character class with simple intersection") {
     val subClasses = Seq("abc", "def", "ghi")
     val pattern = subClasses.mkString("[", "&&", "]")
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Node]
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     assertEquals(parsedTree.children.length, 1)
 
-    val intersection = parsedTree.children.head
-    assert(clue(intersection).isInstanceOf[CharClassIntersection])
+    val intersection = parsedTree.children.head.asInstanceOf[CharClassIntersection]
     assertEquals(intersection.children.length, 3)
     (subClasses zip intersection.children) foreach { case (str, child) =>
       assert(clue(child) match {
@@ -274,9 +272,8 @@ class ParserJVMTest extends ParserTest {
 
   test("Parse long quote with end") {
     val pattern = """stuff\Q$hit\Emorestuff"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Concat]
 
-    assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {
       case Quote("$hit", true, _) => true
       case _                      => false
@@ -287,9 +284,8 @@ class ParserJVMTest extends ParserTest {
 
   test("Parse long quote without end") {
     val pattern = """stuff\Q$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).get.asInstanceOf[Concat]
 
-    assert(clue(parsedTree).isInstanceOf[Concat])
     assert(clue(parsedTree.children(5)) match {
       case Quote("$hit", false, _) => true
       case _                       => false


### PR DESCRIPTION
Move properties that only make sense for a `Node`  to `Node` instead of `RegexTree`. There's a few more pattern matches needed in the code for this, but it is generally cleaner for a `Leaf` to not have `Node` stuff IMO. I've also changed `RegexTree` to a sealed trait and moved `Node` and `Leaf` to the same file, so only those two can ever extend `RegexTree.`