### PR TITLE
feat(parser): Initial support for parsing flags in JS

### DIFF
--- a/core/src/main/scala/weaponregex/constant/ErrorMessage.scala
+++ b/core/src/main/scala/weaponregex/constant/ErrorMessage.scala
@@ -1,0 +1,9 @@
+package weaponregex.constant
+
+case object ErrorMessage {
+  val errorHeader: String = "[Error]"
+  val parserErrorHeader: String = s"$errorHeader Parser: "
+
+  val unsupportedFlavor: String = parserErrorHeader + "Unsupported regex flavor"
+  val jvmWithStringFlags: String = parserErrorHeader + "JVM regex flavor does not support string flags"
+}

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -230,8 +230,15 @@ abstract class Parser(val pattern: String, val flags: String) {
     * @see
     *   [[weaponregex.parser.Parser.codePointEscChar]]
     */
-  def charCodePoint[A: P]: P[MetaChar] = Indexed(s"\\$codePointEscChar" ~ ("{" ~ hexDigit.rep(1) ~ "}").!)
-    .map { case (loc, tail) => MetaChar(codePointEscChar + tail, loc) }
+  def charCodePoint[A: P]: P[MetaChar] =
+    Indexed(s"\\$codePointEscChar" ~ "{" ~ hexDigit.rep(1).! ~ "}")
+      .map {
+        case (loc, hexDigits) if java.lang.Character.isValidCodePoint(Integer.parseInt(hexDigits, 16)) =>
+          MetaChar(s"$codePointEscChar{$hexDigits}", loc)
+        case _ =>
+          Fail
+          null
+      }
 
   /** Used to consume a hexadecimal escape character `\ x` or `\ u` when all other hex related cases are checked and
     * failed to prevent back tracking.

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -2,6 +2,7 @@ package weaponregex.parser
 
 import fastparse.*
 import NoWhitespace.*
+import weaponregex.constant.ErrorMessage
 import weaponregex.model.*
 import weaponregex.model.regextree.*
 import weaponregex.extension.StringExtension.StringIndexExtension
@@ -23,11 +24,10 @@ object Parser {
   def apply(pattern: String, flags: String, flavor: ParserFlavor): Try[RegexTree] =
     flavor match {
       case ParserFlavorJVM =>
-        if (flags.nonEmpty)
-          println("[Warning] Parser: JVM regex flavor does not support string flags. Flags will be ignored.")
-        new ParserJVM(pattern).parse
+        if (flags.nonEmpty) Failure(new RuntimeException(ErrorMessage.jvmWithStringFlags))
+        else new ParserJVM(pattern).parse
       case ParserFlavorJS => new ParserJS(pattern, flags).parse
-      case _              => Failure(new RuntimeException("[Error] Parser: Unsupported regex flavor"))
+      case _              => Failure(new RuntimeException(ErrorMessage.unsupportedFlavor))
     }
 
   /** Apply the parser to parse the given pattern
@@ -632,6 +632,6 @@ abstract class Parser(val pattern: String) {
     */
   def parse: Try[RegexTree] = fastparse.parse(pattern, entry(_)) match {
     case Parsed.Success(regexTree: RegexTree, _) => Success(regexTree)
-    case f: Parsed.Failure                       => Failure(new RuntimeException("[Error] Parser: " + f.msg))
+    case f: Parsed.Failure => Failure(new RuntimeException(ErrorMessage.parserErrorHeader + f.msg))
   }
 }

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -21,13 +21,13 @@ object Parser {
     * @return
     *   A `Success` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Failure` otherwise
     */
-  def apply(pattern: String, flags: String, flavor: ParserFlavor): Try[RegexTree] =
+  def apply(pattern: String, flags: Option[String], flavor: ParserFlavor): Try[RegexTree] =
     flavor match {
       case ParserFlavorJVM =>
-        if (flags.nonEmpty) Failure(new RuntimeException(ErrorMessage.jvmWithStringFlags))
+        if (flags.isDefined) Failure(new IllegalArgumentException(ErrorMessage.jvmWithStringFlags))
         else new ParserJVM(pattern).parse
       case ParserFlavorJS => new ParserJS(pattern, flags).parse
-      case _              => Failure(new RuntimeException(ErrorMessage.unsupportedFlavor))
+      case _              => Failure(new IllegalArgumentException(ErrorMessage.unsupportedFlavor))
     }
 
   /** Apply the parser to parse the given pattern
@@ -36,7 +36,7 @@ object Parser {
     * @return
     *   A `Success` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Failure` otherwise
     */
-  def apply(pattern: String, flavor: ParserFlavor = ParserFlavorJVM): Try[RegexTree] = apply(pattern, "", flavor)
+  def apply(pattern: String, flavor: ParserFlavor = ParserFlavorJVM): Try[RegexTree] = apply(pattern, None, flavor)
 }
 
 /** The based abstract parser

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -22,9 +22,12 @@ object Parser {
     */
   def apply(pattern: String, flags: String, flavor: ParserFlavor): Try[RegexTree] =
     flavor match {
-      case ParserFlavorJVM => new ParserJVM(pattern).parse
-      case ParserFlavorJS  => new ParserJS(pattern, flags).parse
-      case _               => Failure(new RuntimeException("[Error] Parser: Unsupported regex flavor"))
+      case ParserFlavorJVM =>
+        if (flags.nonEmpty)
+          println("[Warning] Parser: JVM regex flavor does not support string flags. Flags will be ignored.")
+        new ParserJVM(pattern).parse
+      case ParserFlavorJS => new ParserJS(pattern, flags).parse
+      case _              => Failure(new RuntimeException("[Error] Parser: Unsupported regex flavor"))
     }
 
   /** Apply the parser to parse the given pattern
@@ -39,14 +42,10 @@ object Parser {
 /** The based abstract parser
   * @param pattern
   *   The regex pattern to be parsed
-  * @param flags
-  *   The regex flags to be used
   * @note
   *   The parsing rules methods inside this class is created based on the defined grammar
   */
-abstract class Parser(val pattern: String, val flags: String) {
-
-  def this(pattern: String) = this(pattern, "")
+abstract class Parser(val pattern: String) {
 
   /** Regex special characters
     */

--- a/core/src/main/scala/weaponregex/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJS.scala
@@ -14,9 +14,12 @@ import weaponregex.model.regextree.*
   *   object
   * @see
   *   [[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet]]
+  * @see
+  *   [[https://tc39.es/ecma262/multipage/text-processing.html#sec-patterns]]
   */
-class ParserJS private[parser] (pattern: String, flags: String) extends Parser(pattern, flags) {
+class ParserJS private[parser] (pattern: String, val flags: String) extends Parser(pattern) {
 
+  /** Whether the flags contain the `u` flag for Unicode mode */
   private val unicodeMode: Boolean = flags.contains("u")
 
   /** Concrete parser for JS flavor of regex

--- a/core/src/main/scala/weaponregex/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJS.scala
@@ -7,13 +7,28 @@ import weaponregex.model.regextree.*
 /** Concrete parser for JS flavor of regex
   * @param pattern
   *   The regex pattern to be parsed
+  * @param flags
+  *   The regex flags to be used
   * @note
   *   This class constructor is private, instances must be created using the companion [[weaponregex.parser.Parser]]
   *   object
   * @see
   *   [[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet]]
   */
-class ParserJS private[parser] (pattern: String) extends Parser(pattern) {
+class ParserJS private[parser] (pattern: String, flags: String) extends Parser(pattern, flags) {
+
+  private val unicodeMode: Boolean = flags.contains("u")
+
+  /** Concrete parser for JS flavor of regex
+    * @param pattern
+    *   The regex pattern to be parsed
+    * @note
+    *   This class constructor is private, instances must be created using the companion [[weaponregex.parser.Parser]]
+    *   object
+    * @see
+    *   [[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet]]
+    */
+  def this(pattern: String) = this(pattern, "")
 
   /** Regex special characters
     */
@@ -39,6 +54,12 @@ class ParserJS private[parser] (pattern: String) extends Parser(pattern) {
     */
   override val minCharClassItem: Int = 0
 
+  /** The escape character used with a code point
+    * @example
+    *   `\ x{h..h}` or `\ u{h..h}`
+    */
+  override val codePointEscChar: String = "u"
+
   /** Parse special cases of a character literal
     * @return
     *   The captured character as a string
@@ -52,15 +73,21 @@ class ParserJS private[parser] (pattern: String) extends Parser(pattern) {
     * @note
     *   Nested character class is a Scala/Java-only regex syntax
     */
-  override def classItem[A: P]: P[RegexTree] = P(
-    preDefinedCharClass | posixCharClass | metaCharacter | range | quoteChar | charClassCharLiteral
-  )
+  override def classItem[A: P]: P[RegexTree] =
+    if (unicodeMode) P(preDefinedCharClass | posixCharClass | metaCharacter | range | quoteChar | charClassCharLiteral)
+    else P(preDefinedCharClass | metaCharacter | range | quoteChar | charClassCharLiteral)
 
-  /** Intermediate parsing rule for quoting tokens which can parse only `quoteChar`
+  /** Parse a quoted character (any character). If [[weaponregex.parser.ParserJS.unicodeMode]] is true, only the
+    * following characters are allowed: `^ $ \ . * + ? ( ) [ ] { } |` or `/`
     * @return
-    *   [[weaponregex.model.regextree.RegexTree]] (sub)tree
+    *   [[weaponregex.model.regextree.QuoteChar]]
+    * @example
+    *   `"\$"`
     */
-  override def quote[A: P]: P[RegexTree] = quoteChar
+  override def quote[A: P]: P[QuoteChar] = if (unicodeMode)
+    Indexed("""\""" ~ CharIn("""^$\.*+?()[]{}|/""").!)
+      .map { case (loc, char) => QuoteChar(char.head, loc) }
+  else quoteChar
 
   /** Parse a character with octal value `\n`, `\nn`, `\mnn` (0 <= m,n <= 9)
     *
@@ -86,5 +113,19 @@ class ParserJS private[parser] (pattern: String) extends Parser(pattern) {
     * @return
     *   [[weaponregex.model.regextree.RegexTree]] (sub)tree
     */
-  override def metaCharacter[A: P]: P[RegexTree] = P(charOct | charHex | charUnicode | escapeChar | controlChar)
+  override def metaCharacter[A: P]: P[RegexTree] =
+    if (unicodeMode) P(charOct | charHex | charUnicode | charCodePoint | escapeChar | controlChar)
+    else P(charOct | charHex | escapeChar | controlChar)
+
+  /** Intermediate parsing rule which can parse either `capturing`, `anyDot`, `preDefinedCharClass`, `boundary`,
+    * `charClass`, `reference`, `character` or `quote`
+    * @return
+    *   [[weaponregex.model.regextree.RegexTree]] (sub)tree
+    */
+  override def elementaryRE[A: P]: P[RegexTree] =
+    if (unicodeMode)
+      P(
+        capturing | anyDot | preDefinedCharClass | posixCharClass | boundary | charClass | reference | character | quote
+      )
+    else P(capturing | anyDot | preDefinedCharClass | boundary | charClass | reference | character | quote)
 }

--- a/core/src/main/scala/weaponregex/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJS.scala
@@ -17,7 +17,7 @@ import weaponregex.model.regextree.*
   * @see
   *   [[https://tc39.es/ecma262/multipage/text-processing.html#sec-patterns]]
   */
-class ParserJS private[parser] (pattern: String, val flags: String = "") extends Parser(pattern) {
+class ParserJS private[parser] (pattern: String, val flags: Option[String] = None) extends Parser(pattern) {
 
   /** Whether the flags contain the `u` flag for Unicode mode */
   private val unicodeMode: Boolean = flags.contains("u")

--- a/core/src/main/scala/weaponregex/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJS.scala
@@ -17,21 +17,10 @@ import weaponregex.model.regextree.*
   * @see
   *   [[https://tc39.es/ecma262/multipage/text-processing.html#sec-patterns]]
   */
-class ParserJS private[parser] (pattern: String, val flags: String) extends Parser(pattern) {
+class ParserJS private[parser] (pattern: String, val flags: String = "") extends Parser(pattern) {
 
   /** Whether the flags contain the `u` flag for Unicode mode */
   private val unicodeMode: Boolean = flags.contains("u")
-
-  /** Concrete parser for JS flavor of regex
-    * @param pattern
-    *   The regex pattern to be parsed
-    * @note
-    *   This class constructor is private, instances must be created using the companion [[weaponregex.parser.Parser]]
-    *   object
-    * @see
-    *   [[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet]]
-    */
-  def this(pattern: String) = this(pattern, "")
 
   /** Regex special characters
     */

--- a/core/src/main/scala/weaponregex/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJVM.scala
@@ -39,6 +39,12 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
     */
   override val minCharClassItem: Int = 1
 
+  /** The escape character used with a code point
+    * @example
+    *   `\ x{h..h}` or `\ u{h..h}`
+    */
+  override val codePointEscChar: String = "x"
+
   /** Parse a character with octal value `\0n`, `\0nn`, `\0mnn` (0 <= m <= 3, 0 <= n <= 7)
     *
     * @return

--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -73,6 +73,7 @@ object WeaponRegeXJS {
     * @return
     *   A JavaScript Array of [[weaponregex.model.mutation.Mutant]] if can be parsed, or throw an exception otherwise
     */
+  @deprecated("Use `mutate(pattern, flags, options)` instead. This will be removed in the future.", "0.7.x")
   @JSExportTopLevel("mutate")
   def mutate(pattern: String, options: MutationOptions = new MutationOptions): js.Array[MutantJS] =
     mutate(pattern, "", options)

--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -25,7 +25,7 @@ object WeaponRegeXJS {
     * @param pattern
     *   Input regex string
     * @param flags
-    *   Regex flags
+    *   Regex flags or `undefined`
     * @param options
     *   JavaScript object for Mutation options
     *   {{{
@@ -38,7 +38,7 @@ object WeaponRegeXJS {
     *   A JavaScript Array of [[weaponregex.model.mutation.Mutant]] if can be parsed, or throw an exception otherwise
     */
   @JSExportTopLevel("mutate")
-  def mutate(pattern: String, flags: String, options: MutationOptions): js.Array[MutantJS] = {
+  def mutate(pattern: String, flags: js.UndefOr[String], options: MutationOptions): js.Array[MutantJS] = {
     val mutators: Seq[TokenMutator] =
       if (options.hasOwnProperty("mutators") && options.mutators != null)
         options.mutators.toSeq map (_.tokenMutator)
@@ -53,7 +53,7 @@ object WeaponRegeXJS {
       if (options.hasOwnProperty("flavor") && options.flavor != null) options.flavor
       else ParserFlavorJS
 
-    Parser(pattern, flags, flavor) match {
+    Parser(pattern, flags.toOption, flavor) match {
       case Success(tree)                 => (tree.mutate(mutators, mutationLevels) map MutantJS).toJSArray
       case Failure(throwable: Throwable) => throw throwable
     }
@@ -76,5 +76,5 @@ object WeaponRegeXJS {
   @deprecated("Use `mutate(pattern, flags, options)` instead. This will be removed in the future.", "0.7.x")
   @JSExportTopLevel("mutate")
   def mutate(pattern: String, options: MutationOptions = new MutationOptions): js.Array[MutantJS] =
-    mutate(pattern, "", options)
+    mutate(pattern, js.undefined, options)
 }

--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -24,6 +24,8 @@ object WeaponRegeXJS {
   /** Mutate using the given mutators at some specific mutation levels
     * @param pattern
     *   Input regex string
+    * @param flags
+    *   Regex flags
     * @param options
     *   JavaScript object for Mutation options
     *   {{{
@@ -36,7 +38,7 @@ object WeaponRegeXJS {
     *   A JavaScript Array of [[weaponregex.model.mutation.Mutant]] if can be parsed, or throw an exception otherwise
     */
   @JSExportTopLevel("mutate")
-  def mutate(pattern: String, options: MutationOptions = new MutationOptions): js.Array[MutantJS] = {
+  def mutate(pattern: String, flags: String, options: MutationOptions): js.Array[MutantJS] = {
     val mutators: Seq[TokenMutator] =
       if (options.hasOwnProperty("mutators") && options.mutators != null)
         options.mutators.toSeq map (_.tokenMutator)
@@ -51,9 +53,27 @@ object WeaponRegeXJS {
       if (options.hasOwnProperty("flavor") && options.flavor != null) options.flavor
       else ParserFlavorJS
 
-    Parser(pattern, flavor) match {
+    Parser(pattern, flags, flavor) match {
       case Success(tree)                 => (tree.mutate(mutators, mutationLevels) map MutantJS).toJSArray
       case Failure(throwable: Throwable) => throw throwable
     }
   }
+
+  /** Mutate using the given mutators at some specific mutation levels
+    * @param pattern
+    *   Input regex string
+    * @param options
+    *   JavaScript object for Mutation options
+    *   {{{
+    * {
+    *   mutators: [Mutators to be used for mutation],
+    *   mutationLevels: [Target mutation levels. If this is `null`, the `mutators` will not be filtered],
+    * }
+    *   }}}
+    * @return
+    *   A JavaScript Array of [[weaponregex.model.mutation.Mutant]] if can be parsed, or throw an exception otherwise
+    */
+  @JSExportTopLevel("mutate")
+  def mutate(pattern: String, options: MutationOptions = new MutationOptions): js.Array[MutantJS] =
+    mutate(pattern, "", options)
 }

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -1,5 +1,6 @@
 package weaponregex
 
+import weaponregex.constant.ErrorMessage
 import weaponregex.model.mutation.Mutant
 import weaponregex.mutator.BuiltinMutators
 
@@ -65,7 +66,7 @@ class WeaponRegeXTest extends munit.FunSuite {
 
     import scala.util.Failure
     assert(clue(mutations) match {
-      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith(ErrorMessage.parserErrorHeader)
       case _                                    => false
     })
   }

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -9,7 +9,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
   val charClassPredefCharClasses: String = """\d\D\s\S\v\w\W"""
   val charClassSpecialChars: String = "(){}.^$|?*+"
   val escapeCharacters: String = """\\\t\n\r\f"""
-  val hexCharacters: String = "\\x20\\u0020"
+  val hexCharacters: String = "\\x20\\x21"
   val octCharacters: String = """\1\12\123"""
   val predefCharClasses: String = "." + charClassPredefCharClasses
 
@@ -62,13 +62,124 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse \\x{20} as quantifier") {
+  test("Parse `\\u20` as character quotation without the Unicode flag") {
+    val pattern = "\\u20"
+    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Concat]
+
+    assert(clue(parsedTree.children.head) match {
+      case QuoteChar('u', _) => true
+      case _                 => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse `\\u{20}` as quantifier without the Unicode flag") {
+    val pattern = "\\u{20}"
+    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Quantifier]
+
+    assert(clue(parsedTree) match {
+      case Quantifier(QuoteChar('u', _), 20, 20, _, GreedyQuantifier, true) => true
+      case _                                                                => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse `\\x{20}` as quantifier without the Unicode flag") {
     val pattern = "\\x{20}"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Quantifier]
+    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Quantifier]
 
     assert(clue(parsedTree) match {
       case Quantifier(QuoteChar('x', _), 20, 20, _, GreedyQuantifier, true) => true
       case _                                                                => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse `\\u20` as a character quotation without the Unicode flag") {
+    val pattern = "\\u20"
+    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Concat]
+
+    assert(clue(parsedTree.children.head) match {
+      case QuoteChar('u', _) => true
+      case _                 => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse `\\u{20}` as Unicode character with the Unicode flag") {
+    val pattern = "\\u{20}"
+    val parsedTree = Parser(pattern, "u", parserFlavor).get.to[MetaChar]
+
+    assertEquals(parsedTree.metaChar, "u{20}")
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Unparsable: `\\x{20}` with the Unicode flag") {
+    val pattern = "\\x{20}"
+    parseErrorTest(pattern, "u")
+  }
+
+  test("Unparsable: `\\u20` with the Unicode flag") {
+    val pattern = "\\u20"
+    parseErrorTest(pattern, "u")
+  }
+
+  test("Parse character class with POSIX character classes with the Unicode flag") {
+    val pattern = """[\p{Alpha}\P{hello_World_0123}]"""
+    val parsedTree = Parser(pattern, "u", parserFlavor).get.to[CharacterClass]
+
+    assert(clue(parsedTree.children.head) match {
+      case POSIXCharClass("Alpha", _, true) => true
+      case _                                => false
+    })
+    assert(clue(parsedTree.children.last) match {
+      case POSIXCharClass("hello_World_0123", _, false) => true
+      case _                                            => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse POSIX character classes with the Unicode flag") {
+    val pattern = """\p{Alpha}\P{hello_World_0123}"""
+    val parsedTree = Parser(pattern, "u", parserFlavor).get.to[Concat]
+
+    assert(clue(parsedTree.children.head) match {
+      case POSIXCharClass("Alpha", _, true) => true
+      case _                                => false
+    })
+    assert(clue(parsedTree.children.last) match {
+      case POSIXCharClass("hello_World_0123", _, false) => true
+      case _                                            => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse `\\p{Alpha}` as a character quotation in a character class without the Unicode flag") {
+    val pattern = """[\p{Alpha}]"""
+    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+
+    assert(clue(parsedTree.children.head) match {
+      case QuoteChar('p', _) => true
+      case _                 => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse `\\p{Alpha}` as a character quotation without the Unicode flag") {
+    val pattern = """\p{Alpha}"""
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+
+    assert(clue(parsedTree.children.head) match {
+      case QuoteChar('p', _) => true
+      case _                 => false
     })
 
     treeBuildTest(parsedTree, pattern)
@@ -164,6 +275,27 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
     })
 
     treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse syntax characters escape with the Unicode flag") {
+    val syntaxChars = """^$\.*+?()[]{}|/"""
+    val pattern = "\\" + syntaxChars.mkString("\\")
+    val parsedTree = Parser(pattern, "u", parserFlavor).get.to[Concat]
+
+    syntaxChars zip parsedTree.children foreach { case (char, child) =>
+      assert(clue(child) match {
+        case MetaChar(c, _)  => c.head == char
+        case QuoteChar(c, _) => c == char
+        case _               => false
+      })
+    }
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Unparsable: non-syntax character escape with the Unicode flag") {
+    val pattern = "\\a"
+    parseErrorTest(pattern, "u")
   }
 
   test("Unparsable: long-quantifier-like with nothing preceding") {

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -62,6 +62,24 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Parse non-hexadecimal value `\\xGG`") {
+    val pattern = "\\xGG"
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+
+    assertEquals(parsedTree.children.length, 3)
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse non-unicode value `\\uGGGG`") {
+    val pattern = "\\uGGGG"
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+
+    assertEquals(parsedTree.children.length, 5)
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
   test("Parse `\\u20` as character quotation without the Unicode flag") {
     val pattern = "\\u20"
     val parsedTree = Parser(pattern, "", parserFlavor).get.to[Concat]
@@ -93,18 +111,6 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
     assert(clue(parsedTree) match {
       case Quantifier(QuoteChar('x', _), 20, 20, _, GreedyQuantifier, true) => true
       case _                                                                => false
-    })
-
-    treeBuildTest(parsedTree, pattern)
-  }
-
-  test("Parse `\\u20` as a character quotation without the Unicode flag") {
-    val pattern = "\\u20"
-    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Concat]
-
-    assert(clue(parsedTree.children.head) match {
-      case QuoteChar('u', _) => true
-      case _                 => false
     })
 
     treeBuildTest(parsedTree, pattern)
@@ -304,7 +310,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
       "{1,}",
       "{1,2}"
     )
-    patterns map parseErrorTest
+    patterns.foreach(parseErrorTest(_))
   }
 
   test("Parse `{`") {

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -82,7 +82,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\u20` as character quotation without the Unicode flag") {
     val pattern = "\\u20"
-    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, None, parserFlavor).get.to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case QuoteChar('u', _) => true
@@ -94,7 +94,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\u{20}` as quantifier without the Unicode flag") {
     val pattern = "\\u{20}"
-    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Quantifier]
+    val parsedTree = Parser(pattern, None, parserFlavor).get.to[Quantifier]
 
     assert(clue(parsedTree) match {
       case Quantifier(QuoteChar('u', _), 20, 20, _, GreedyQuantifier, true) => true
@@ -106,7 +106,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\x{20}` as quantifier without the Unicode flag") {
     val pattern = "\\x{20}"
-    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Quantifier]
+    val parsedTree = Parser(pattern, None, parserFlavor).get.to[Quantifier]
 
     assert(clue(parsedTree) match {
       case Quantifier(QuoteChar('x', _), 20, 20, _, GreedyQuantifier, true) => true
@@ -118,7 +118,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\u{FFFFFF}` as character quotation without the Unicode flag") {
     val pattern = "\\u{FFFFFF}"
-    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, None, parserFlavor).get.to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case QuoteChar('u', _) => true
@@ -130,7 +130,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\u{20}` as Unicode character with the Unicode flag") {
     val pattern = "\\u{20}"
-    val parsedTree = Parser(pattern, "u", parserFlavor).get.to[MetaChar]
+    val parsedTree = Parser(pattern, Some("u"), parserFlavor).get.to[MetaChar]
 
     assertEquals(parsedTree.metaChar, "u{20}")
 
@@ -139,22 +139,22 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Unparsable: `\\x{20}` with the Unicode flag") {
     val pattern = "\\x{20}"
-    parseErrorTest(pattern, "u")
+    parseErrorTest(pattern, Some("u"))
   }
 
   test("Unparsable: `\\u20` with the Unicode flag") {
     val pattern = "\\u20"
-    parseErrorTest(pattern, "u")
+    parseErrorTest(pattern, Some("u"))
   }
 
   test("Unparsable: out-of-range code point hexadecimal values with the Unicode flag") {
     val pattern = "\\u{110000}" // 10FFFF + 1
-    parseErrorTest(pattern, "u")
+    parseErrorTest(pattern, Some("u"))
   }
 
   test("Parse character class with POSIX character classes with the Unicode flag") {
     val pattern = """[\p{Alpha}\P{hello_World_0123}]"""
-    val parsedTree = Parser(pattern, "u", parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, Some("u"), parserFlavor).get.to[CharacterClass]
 
     assert(clue(parsedTree.children.head) match {
       case POSIXCharClass("Alpha", _, true) => true
@@ -170,7 +170,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse POSIX character classes with the Unicode flag") {
     val pattern = """\p{Alpha}\P{hello_World_0123}"""
-    val parsedTree = Parser(pattern, "u", parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, Some("u"), parserFlavor).get.to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case POSIXCharClass("Alpha", _, true) => true
@@ -303,7 +303,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
   test("Parse syntax characters escape with the Unicode flag") {
     val syntaxChars = """^$\.*+?()[]{}|/"""
     val pattern = "\\" + syntaxChars.mkString("\\")
-    val parsedTree = Parser(pattern, "u", parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, Some("u"), parserFlavor).get.to[Concat]
 
     syntaxChars zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -318,7 +318,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Unparsable: non-syntax character escape with the Unicode flag") {
     val pattern = "\\a"
-    parseErrorTest(pattern, "u")
+    parseErrorTest(pattern, Some("u"))
   }
 
   test("Unparsable: long-quantifier-like with nothing preceding") {

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -62,7 +62,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse non-hexadecimal value `\\xGG`") {
+  test("Parse non-hexadecimal value `\\xGG`  without the Unicode flag") {
     val pattern = "\\xGG"
     val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
 
@@ -71,7 +71,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse non-unicode value `\\uGGGG`") {
+  test("Parse non-unicode value `\\uGGGG` without the Unicode flag") {
     val pattern = "\\uGGGG"
     val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
 
@@ -116,6 +116,18 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Parse `\\u{FFFFFF}` as character quotation without the Unicode flag") {
+    val pattern = "\\u{FFFFFF}"
+    val parsedTree = Parser(pattern, "", parserFlavor).get.to[Concat]
+
+    assert(clue(parsedTree.children.head) match {
+      case QuoteChar('u', _) => true
+      case _                 => false
+    })
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
   test("Parse `\\u{20}` as Unicode character with the Unicode flag") {
     val pattern = "\\u{20}"
     val parsedTree = Parser(pattern, "u", parserFlavor).get.to[MetaChar]
@@ -132,6 +144,11 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Unparsable: `\\u20` with the Unicode flag") {
     val pattern = "\\u20"
+    parseErrorTest(pattern, "u")
+  }
+
+  test("Unparsable: out-of-range code point hexadecimal values with the Unicode flag") {
+    val pattern = "\\u{110000}" // 10FFFF + 1
     parseErrorTest(pattern, "u")
   }
 

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -125,6 +125,11 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
     patterns.foreach(parseErrorTest(_))
   }
 
+  test("Unparsable: out-of-range code point hexadecimal values") {
+    val pattern = "\\x{110000}" // 10FFFF + 1
+    parseErrorTest(pattern)
+  }
+
   test("Parse character class with POSIX character classes") {
     val pattern = """[\p{Alpha}\P{hello_World_0123}]"""
     val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -113,7 +113,16 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
       "[a&&&&]",
       "[a&&&&a]"
     )
-    patterns foreach parseErrorTest
+    patterns.foreach(parseErrorTest(_))
+  }
+
+  test("Unparsable: non-hexadecimal values") {
+    val patterns = Seq(
+      "\\xGG",
+      "\\x{GG}",
+      "\\uGGGG"
+    )
+    patterns.foreach(parseErrorTest(_))
   }
 
   test("Parse character class with POSIX character classes") {

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -344,6 +344,6 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Unparsable: JVM flavor with String flags") {
     val pattern = "abc"
-    parseErrorTest(pattern, "u")
+    parseErrorTest(pattern, Some("u"))
   }
 }

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -341,4 +341,9 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
     val pattern = "{"
     parseErrorTest(pattern)
   }
+
+  test("Unparsable: JVM flavor with String flags") {
+    val pattern = "abc"
+    parseErrorTest(pattern, "u")
+  }
 }

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -22,14 +22,16 @@ trait ParserTest {
 
   def treeBuildTest(tree: RegexTree, pattern: String): Unit = assertEquals(tree.build, pattern)
 
-  def parseErrorTest(pattern: String): Unit = {
-    val parsedTree = Parser(pattern, parserFlavor)
+  def parseErrorTest(pattern: String, flags: String): Unit = {
+    val parsedTree = Parser(pattern, flags, parserFlavor)
 
     assert(clue(parsedTree) match {
       case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
       case _                                    => false
     })
   }
+
+  def parseErrorTest(pattern: String): Unit = parseErrorTest(pattern, "")
 
   test("Parse concat of characters") {
     val pattern = "hello"
@@ -216,22 +218,6 @@ trait ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
-  test("Parse character class with POSIX character classes") {
-    val pattern = """[\p{Alpha}\P{hello_World_0123}]"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
-
-    assert(clue(parsedTree.children.head) match {
-      case POSIXCharClass("Alpha", _, true) => true
-      case _                                => false
-    })
-    assert(clue(parsedTree.children.last) match {
-      case POSIXCharClass("hello_World_0123", _, false) => true
-      case _                                            => false
-    })
-
-    treeBuildTest(parsedTree, pattern)
-  }
-
   test("Parse character class with quotes") {
     val pattern = """[\]]"""
     val parsedTree = Parser(pattern, parserFlavor).get
@@ -342,22 +328,6 @@ trait ParserTest {
         case _                                 => false
       })
     }
-
-    treeBuildTest(parsedTree, pattern)
-  }
-
-  test("Parse POSIX character classes") {
-    val pattern = """\p{Alpha}\P{hello_World_0123}"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
-
-    assert(clue(parsedTree.children.head) match {
-      case POSIXCharClass("Alpha", _, true) => true
-      case _                                => false
-    })
-    assert(clue(parsedTree.children.last) match {
-      case POSIXCharClass("hello_World_0123", _, false) => true
-      case _                                            => false
-    })
 
     treeBuildTest(parsedTree, pattern)
   }

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -22,7 +22,7 @@ trait ParserTest {
 
   def treeBuildTest(tree: RegexTree, pattern: String): Unit = assertEquals(tree.build, pattern)
 
-  def parseErrorTest(pattern: String, flags: String): Unit = {
+  def parseErrorTest(pattern: String, flags: String = ""): Unit = {
     val parsedTree = Parser(pattern, flags, parserFlavor)
 
     assert(clue(parsedTree) match {
@@ -30,8 +30,6 @@ trait ParserTest {
       case _                                    => false
     })
   }
-
-  def parseErrorTest(pattern: String): Unit = parseErrorTest(pattern, "")
 
   test("Parse concat of characters") {
     val pattern = "hello"

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -1,6 +1,7 @@
 package weaponregex.parser
 
 import munit.Location
+import weaponregex.constant.ErrorMessage
 import weaponregex.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.model.regextree.*
 
@@ -26,7 +27,7 @@ trait ParserTest {
     val parsedTree = Parser(pattern, flags, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case Failure(exception: RuntimeException) => exception.getMessage.startsWith("[Error] Parser:")
+      case Failure(exception: RuntimeException) => exception.getMessage.startsWith(ErrorMessage.parserErrorHeader)
       case _                                    => false
     })
   }

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -23,7 +23,7 @@ trait ParserTest {
 
   def treeBuildTest(tree: RegexTree, pattern: String): Unit = assertEquals(tree.build, pattern)
 
-  def parseErrorTest(pattern: String, flags: String = ""): Unit = {
+  def parseErrorTest(pattern: String, flags: Option[String] = None): Unit = {
     val parsedTree = Parser(pattern, flags, parserFlavor)
 
     assert(clue(parsedTree) match {

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weaponregex-test",
   "version": "1.0.0",
-  "description": "Integration tests for the JS varaint of Weapon regeX ",
+  "description": "Integration tests for the JS variant of Weapon regeX ",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/node/test/api.js
+++ b/node/test/api.js
@@ -28,6 +28,35 @@ describe('Weapon regeX', () => {
       assert.strictEqual(mutants.length, 1);
     });
 
+    it('Can mutate with JS regex flavor', () => {
+      const mutants = wrx.mutate('\\x{20}', {
+        flavor: wrx.ParserFlavorJS,
+      });
+      assert.strictEqual(mutants.length, 4);
+    });
+
+    it('Can mutate with JVM regex flavor', () => {
+      const mutants = wrx.mutate('\\x{20}', {
+        flavor: wrx.ParserFlavorJVM,
+      });
+      assert.strictEqual(mutants.length, 0);
+    });
+
+    it('Can mutate with flags', () => {
+      const mutants = wrx.mutate('\\u{20}', 'u', {});
+      assert.strictEqual(mutants.length, 0);
+    });
+
+    it('Can mutate with `undefined` as flags', () => {
+      const mutants = wrx.mutate('\\u{20}', undefined, {});
+      assert.strictEqual(mutants.length, 4);
+    });
+
+    it('Can mutate with `null` as flags', () => {
+      const mutants = wrx.mutate('\\u{20}', null, {});
+      assert.strictEqual(mutants.length, 4);
+    });
+
     it('Returns an empty array if there are no mutants', () => {
       const mutants = wrx.mutate('a');
       assert.deepStrictEqual(mutants, []);


### PR DESCRIPTION
+ Initial support for parsing flags in JS
+ Add and update JS parsing rules that are affected by the Unicode flag `u`. Specifically, with the `u` flag:
  * `\u` marks the start of a Unicode escape sequence, otherwise it matches the character `u`
  * `\p{UnicodeProperty}` matches a Unicode property escape, otherwise it matches the character `p` followed by the string `{UnicodeProperty}`
  * a character identity escape `\x` is only valid if `x` is a syntax character `^ $ \ . * + ? ( ) [ ] { } |` or `/`. Without the `u` flag, a character identity escape accepts other characters
+ Add and update tests for parsing rules that are affected by the Unicode flag `u`
