### PR TITLE
fix(parser): correct hex and unicode values

### DIFF
--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -178,7 +178,7 @@ abstract class Parser(val pattern: String) {
     * @example
     *   `"\x01"`
     */
-  def charHex[A: P]: P[MetaChar] = Indexed("""\x""" ~ CharIn("0-9a-zA-Z").rep(exactly = 2).!)
+  def charHex[A: P]: P[MetaChar] = Indexed("""\x""" ~ CharIn("0-9a-fA-F").rep(exactly = 2).!)
     .map { case (loc, hexDigits) => MetaChar("x" + hexDigits, loc) }
 
   /** Parse a unicode character `\ uhhhh`
@@ -187,7 +187,7 @@ abstract class Parser(val pattern: String) {
     * @example
     *   `"\ u0020"`
     */
-  def charUnicode[A: P]: P[MetaChar] = Indexed("\\u" ~ CharIn("0-9a-zA-Z").rep(exactly = 4).!)
+  def charUnicode[A: P]: P[MetaChar] = Indexed("\\u" ~ CharIn("0-9a-fA-F").rep(exactly = 4).!)
     .map { case (loc, hexDigits) => MetaChar("u" + hexDigits, loc) }
 
   /** Parse a character with hexadecimal value with braces `\x{h...h}` (Character.MIN_CODE_POINT <= 0xh...h <=
@@ -197,7 +197,7 @@ abstract class Parser(val pattern: String) {
     * @example
     *   `"\x{0123}"`
     */
-  def charHexBrace[A: P]: P[MetaChar] = Indexed("""\x{""" ~ CharIn("0-9a-zA-Z").rep(1).! ~ "}")
+  def charHexBrace[A: P]: P[MetaChar] = Indexed("""\x{""" ~ CharIn("0-9a-fA-F").rep(1).! ~ "}")
     .map { case (loc, hexDigits) => MetaChar("x{" + hexDigits + "}", loc) }
 
   /** Parse a character range inside a character class

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -291,6 +291,11 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Parse non-hexadecimal value \\x{GG}") {
+    val pattern = "\\x{GG}"
+    parseErrorTest(pattern)
+  }
+
   test("Unparsable: single `{`") {
     val pattern = "{"
     parseErrorTest(pattern)

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -672,6 +672,24 @@ trait ParserTest {
     parseErrorTest(pattern)
   }
 
+  test("Parse non-hexadecimal value \\xGG") {
+    val pattern = "\\xGG"
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+
+    assertEquals(parsedTree.children.length, 3)
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse non-unicode value \\uGGGG") {
+    val pattern = "\\uGGGG"
+    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+
+    assertEquals(parsedTree.children.length, 5)
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
   implicit class RegexTreeCastExtension(tree: RegexTree) {
     def to[T <: RegexTree](implicit ct: ClassTag[T], loc: Location): T = tree match {
       case t: T => t


### PR DESCRIPTION
Correct the parsing of hexadecimal (`\xhh` and `\x{h..h}`) and unicode (`\uhhhh`) values by restricting the set of allowed characters represented by `h` in these examples from `[0-9a-zA-Z]` to `[0-9a-fA-F]`. I.e., only hexadecimal value characters.