### PR TITLE
feat: `mutate` and `parse` returns a `Either` instead of `Try`

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,4 @@
+OrganizeImports {
+  coalesceToWildcardImportThreshold = 5
+  groupedImports = Merge
+}

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 
 <img src="images/WeaponRegeX_logo.svg" width="50%" alt="Weapon regeX Logo">
 
-Weapon regeX mutates regular expressions for use in mutation testing. It has been designed from the ground up 
+Weapon regeX mutates regular expressions for use in mutation testing. It has been designed from the ground up
 to support [Stryker Mutator](https://github.com/stryker-mutator). Weapon regeX is available for both
-JavaScript and Scala and is used in [Stryker4s](https://github.com/stryker-mutator/stryker4s) and 
-[StrykerJS](https://github.com/stryker-mutator/stryker-js) flavors of Stryker. 
+JavaScript and Scala and is used in [Stryker4s](https://github.com/stryker-mutator/stryker4s) and
+[StrykerJS](https://github.com/stryker-mutator/stryker-js) flavors of Stryker.
 The JavaScript version of the library is generated from Scala using [Scala.js](https://www.scala-js.org/).
 The generated mutant regular expressions cover human errors, such as edge cases and typos. A list of provided mutators is given below.
 For an introduction to mutation testing, see [Stryker's website](https://stryker-mutator.io/).
 
-
 The current supported versions for Scala are: `2.12` and `2.13`.
 
 # Getting started
+
 In case you want to incorporate Weapon-regeX into your project.
 
 ## Scala
@@ -32,11 +32,10 @@ Mutate!
 
 ```scala
 import weaponregex.WeaponRegeX
-import scala.util.{Try, Success, Failure}
 
 WeaponRegeX.mutate("^abc(d+|[xyz])$") match {
-  case Success(mutants) => mutants map (_.pattern)
-  case Failure(e)       => throw e
+  case Right(mutants) => mutants map (_.pattern)
+  case Left(e)       => throw new RuntimeException(e)
 }
 // res0: Seq[String] = List(
 //   "abc(d+|[xyz])$",
@@ -97,10 +96,10 @@ def mutate(
   mutators: Seq[TokenMutator] = BuiltinMutators.all,
   mutationLevels: Seq[Int] = null,
   flavor: ParserFlavor = ParserFlavorJVM
-): Try[Seq[Mutant]] = ???
+): Either[String, Seq[Mutant]] = ???
 
 WeaponRegeX.mutate _
-// res1: (String, Seq[TokenMutator], Seq[Int], ParserFlavor) => Try[Seq[Mutant]] = <function4>
+// res1: (String, Seq[TokenMutator], Seq[Int], ParserFlavor) => Either[String, Seq[Mutant]] = <function4>
 ```
 
 With the `mutators` argument you can give a select list of mutators that should be used in
@@ -110,10 +109,10 @@ depending on the `mutationLevels` argument.
 A list of `mutationLevels` can also be passed to the function. The mutators will be filtered
 based on the levels in the list. If omitted, no filtering takes place.
 
-The `flavor` argument allows setting the parser flavor that will be used to parse the pattern. 
+The `flavor` argument allows setting the parser flavor that will be used to parse the pattern.
 Currently, we support a `ParserFlavorJVM` and `ParserFlavorJS`. By default in Scala the JVM flavor is used.
 
-This function will return a `Success` with `Seq[Mutant]` if it can be parsed, or a `Failure` otherwise.
+This function will return a `Right` with `Seq[Mutant]` if it can be parsed, or a `Left` with the error message otherwise.
 
 ## JavaScript
 
@@ -122,10 +121,10 @@ The `mutate` function can be called with regular expression flags and an options
 ```js
 import wrx from 'weapon-regex';
 
-let mutants = wrx.mutate('^abc(d+|[xyz])$', "u", {
+let mutants = wrx.mutate('^abc(d+|[xyz])$', 'u', {
   mutators: Array.from(wrx.mutators.values()),
   mutationLevels: [1, 2, 3],
-  flavor: ParserFlavorJS
+  flavor: ParserFlavorJS,
 });
 ```
 
@@ -139,30 +138,30 @@ This function will return a JavaScript Array of `Mutant` if it can be parsed, or
 
 All the supported mutators and at which mutation level they appear are shown in the table below.
 
-| Name                                                            |  1  |  2  |  3  |
+| Name                                                            | 1   | 2   | 3   |
 | --------------------------------------------------------------- | --- | --- | --- |
-| [BOLRemoval](#bolremoval)                                       |  ✅  |  ✅  |  ✅  |
-| [EOLRemoval](#eolremoval)                                       |  ✅  |  ✅  |  ✅  |
-| [BOL2BOI](#bol2boi)                                             |     |  ✅  |  ✅  |
-| [EOL2EOI](#eol2eoi)                                             |     |  ✅  |  ✅  |
-| [CharClassNegation](#charclassnegation)                         |  ✅  |
-| [CharClassChildRemoval](#charclasschildremoval)                 |     |  ✅  |  ✅  |
-| [CharClassAnyChar](#charclassanychar)                           |     |  ✅  |  ✅  |
-| [CharClassRangeModification](#charclassrangemodification)       |     |     |  ✅  |
-| [PredefCharClassNegation](#predefcharclassnegation)             |  ✅  |
-| [PredefCharClassNullification](#predefcharclassnullification)   |     |  ✅  |  ✅  |
-| [PredefCharClassAnyChar](#predefcharclassanychar)               |     |  ✅  |  ✅  |
-| [POSIXCharClassNegation](#posixcharclassnegation)               |  ✅  |
-| [QuantifierRemoval](#quantifierremoval)                         |  ✅  |
-| [QuantifierNChange](#quantifiernchange)                         |     |  ✅  |  ✅  |
-| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     |  ✅  |  ✅  |
-| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     |  ✅  |  ✅  |
-| [QuantifierNMModification](#quantifiernmmodification)           |     |  ✅  |  ✅  |
-| [QuantifierShortModification](#quantifiershortmodification)     |     |  ✅  |  ✅  |
-| [QuantifierShortChange](#quantifiershortchange)                 |     |  ✅  |  ✅  |
-| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     |  ✅  |
-| [GroupToNCGroup](#grouptoncgroup)                               |     |  ✅  |  ✅  |
-| [LookaroundNegation](#lookaroundnegation)                       |  ✅  |  ✅  |  ✅  |
+| [BOLRemoval](#bolremoval)                                       | ✅  | ✅  | ✅  |
+| [EOLRemoval](#eolremoval)                                       | ✅  | ✅  | ✅  |
+| [BOL2BOI](#bol2boi)                                             |     | ✅  | ✅  |
+| [EOL2EOI](#eol2eoi)                                             |     | ✅  | ✅  |
+| [CharClassNegation](#charclassnegation)                         | ✅  |
+| [CharClassChildRemoval](#charclasschildremoval)                 |     | ✅  | ✅  |
+| [CharClassAnyChar](#charclassanychar)                           |     | ✅  | ✅  |
+| [CharClassRangeModification](#charclassrangemodification)       |     |     | ✅  |
+| [PredefCharClassNegation](#predefcharclassnegation)             | ✅  |
+| [PredefCharClassNullification](#predefcharclassnullification)   |     | ✅  | ✅  |
+| [PredefCharClassAnyChar](#predefcharclassanychar)               |     | ✅  | ✅  |
+| [POSIXCharClassNegation](#posixcharclassnegation)               | ✅  |
+| [QuantifierRemoval](#quantifierremoval)                         | ✅  |
+| [QuantifierNChange](#quantifiernchange)                         |     | ✅  | ✅  |
+| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     | ✅  | ✅  |
+| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     | ✅  | ✅  |
+| [QuantifierNMModification](#quantifiernmmodification)           |     | ✅  | ✅  |
+| [QuantifierShortModification](#quantifiershortmodification)     |     | ✅  | ✅  |
+| [QuantifierShortChange](#quantifiershortchange)                 |     | ✅  | ✅  |
+| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     | ✅  |
+| [GroupToNCGroup](#grouptoncgroup)                               |     | ✅  | ✅  |
+| [LookaroundNegation](#lookaroundnegation)                       | ✅  | ✅  | ✅  |
 
 ## Boundary Mutators
 
@@ -443,13 +442,12 @@ Change a normal group to a non-capturing group.
 
 Flips the sign of a lookaround (lookahead, lookbehind) construct.
 
-| Original    | Mutated    |
-| ----------- | ---------- |
-| `(?=abc)`   | `(?!abc)`  |
-| `(?!abc)`   | `(?=abc)`  |
-| `(?<=abc)`  | `(?<!abc)` |
-| `(?<!abc)`  | `(?<=abc)` |
-
+| Original   | Mutated    |
+| ---------- | ---------- |
+| `(?=abc)`  | `(?!abc)`  |
+| `(?!abc)`  | `(?=abc)`  |
+| `(?<=abc)` | `(?<!abc)` |
+| `(?<!abc)` | `(?<=abc)` |
 
 [Back to table 🔝](#supported-mutators)
 

--- a/core/src/main/scala/weaponregex/WeaponRegeX.scala
+++ b/core/src/main/scala/weaponregex/WeaponRegeX.scala
@@ -5,8 +5,6 @@ import weaponregex.model.mutation.*
 import weaponregex.mutator.BuiltinMutators
 import weaponregex.parser.{Parser, ParserFlavor, ParserFlavorJVM}
 
-import scala.util.Try
-
 /** The API facade of Weapon regeX for Scala/JVM
   */
 object WeaponRegeX {
@@ -19,12 +17,12 @@ object WeaponRegeX {
     * @param mutationLevels
     *   Target mutation levels. If this is `null`, the `mutators` will not be filtered.
     * @return
-    *   A `Success` of a sequence of [[weaponregex.model.mutation.Mutant]] if can be parsed, a `Failure` otherwise
+    *   A `Right` of a sequence of [[weaponregex.model.mutation.Mutant]] if can be parsed, a `Left` with the error message otherwise
     */
   def mutate(
       pattern: String,
       mutators: Seq[TokenMutator] = BuiltinMutators.all,
       mutationLevels: Seq[Int] = null,
       flavor: ParserFlavor = ParserFlavorJVM
-  ): Try[Seq[Mutant]] = Parser(pattern, flavor) map (_.mutate(mutators, mutationLevels))
+  ): Either[String, Seq[Mutant]] = Parser(pattern, flavor) map (_.mutate(mutators, mutationLevels))
 }

--- a/core/src/main/scala/weaponregex/WeaponRegeX.scala
+++ b/core/src/main/scala/weaponregex/WeaponRegeX.scala
@@ -17,7 +17,8 @@ object WeaponRegeX {
     * @param mutationLevels
     *   Target mutation levels. If this is `null`, the `mutators` will not be filtered.
     * @return
-    *   A `Right` of a sequence of [[weaponregex.model.mutation.Mutant]] if can be parsed, a `Left` with the error message otherwise
+    *   A `Right` of a sequence of [[weaponregex.model.mutation.Mutant]] if can be parsed, a `Left` with the error
+    *   message otherwise
     */
   def mutate(
       pattern: String,

--- a/core/src/main/scala/weaponregex/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/parser/Parser.scala
@@ -17,7 +17,8 @@ object Parser {
     * @param flags
     *   The regex flags to be used
     * @return
-    *   A `Right` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Left` with the error message otherwise
+    *   A `Right` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Left` with the error message
+    *   otherwise
     */
   def apply(pattern: String, flags: Option[String], flavor: ParserFlavor): Either[String, RegexTree] =
     flavor match {
@@ -32,7 +33,8 @@ object Parser {
     * @param pattern
     *   The regex pattern to be parsed
     * @return
-    *   A `Right` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Left` with the error message otherwise
+    *   A `Right` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Left` with the error message
+    *   otherwise
     */
   def apply(pattern: String, flavor: ParserFlavor = ParserFlavorJVM): Either[String, RegexTree] =
     apply(pattern, None, flavor)
@@ -627,7 +629,8 @@ abstract class Parser(val pattern: String) {
 
   /** Parse the given regex pattern
     * @return
-    *   A `Right` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Left` with the error message otherwise
+    *   A `Right` of parsed [[weaponregex.model.regextree.RegexTree]] if can be parsed, a `Left` with the error message
+    *   otherwise
     */
   def parse: Either[String, RegexTree] = fastparse.parse(pattern, entry(_)) match {
     case Parsed.Success(regexTree: RegexTree, _) => Right(regexTree)

--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -8,7 +8,6 @@ import weaponregex.parser.{Parser, ParserFlavor, ParserFlavorJS}
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.*
 import scala.scalajs.js.annotation.*
-import scala.util.{Failure, Success}
 
 /** The API facade of Weapon regeX for JavaScript
   * @note
@@ -54,8 +53,8 @@ object WeaponRegeXJS {
       else ParserFlavorJS
 
     Parser(pattern, flags.toOption, flavor) match {
-      case Success(tree)                 => (tree.mutate(mutators, mutationLevels) map MutantJS).toJSArray
-      case Failure(throwable: Throwable) => throw throwable
+      case Right(tree) => (tree.mutate(mutators, mutationLevels) map MutantJS).toJSArray
+      case Left(msg)   => throw new RuntimeException(msg)
     }
   }
 

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -54,11 +54,10 @@ class WeaponRegeXTest extends munit.FunSuite {
     assertEquals(mutations, Nil)
   }
 
-  test("Returns an empty sequence if the regex is invalid") {
-    val mutations = WeaponRegeX.mutate("*(a|$]").fold(fail(_), identity)
+  test("Returns a Left with error message if the regex is invalid") {
+    val mutations = WeaponRegeX.mutate("*(a|$]")
 
-    assert(mutations.isInstanceOf[Seq[Mutant]])
-    assertEquals(mutations, Nil)
+    assertEquals(mutations, Left("[Error] Parser: Position 1:1, found \"*(a|$]\""))
   }
 
   test("Returns when Parser failed") {

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -64,10 +64,9 @@ class WeaponRegeXTest extends munit.FunSuite {
   test("Returns when Parser failed") {
     val mutations = WeaponRegeX.mutate("(")
 
-    import scala.util.Failure
     assert(clue(mutations) match {
-      case Failure(exception: RuntimeException) => exception.getMessage.startsWith(ErrorMessage.parserErrorHeader)
-      case _                                    => false
+      case Left(msg) => msg.startsWith(ErrorMessage.parserErrorHeader)
+      case _         => false
     })
   }
 }

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -6,56 +6,56 @@ import weaponregex.mutator.BuiltinMutators
 
 class WeaponRegeXTest extends munit.FunSuite {
   test("Can mutate without options") {
-    val mutations = WeaponRegeX.mutate("^a").getOrElse(Nil)
+    val mutations = WeaponRegeX.mutate("^a").fold(fail(_), identity)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 2)
   }
 
   test("Can mutate with only mutators as option") {
-    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all).getOrElse(Nil)
+    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all).fold(fail(_), identity)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 2)
   }
 
   test("Can mutate with empty sequence of mutators as option") {
-    val mutations = WeaponRegeX.mutate("^a", Nil).getOrElse(Nil)
+    val mutations = WeaponRegeX.mutate("^a", Nil).fold(fail(_), identity)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Can mutate with only levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(1)).getOrElse(Nil)
+    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(1)).fold(fail(_), identity)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 1)
   }
 
   test("Can mutate with unsupported levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(100, 1000)).getOrElse(Nil)
+    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(100, 1000)).fold(fail(_), identity)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Can mutate with both mutators and levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all, Seq(1)).getOrElse(Nil)
+    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all, Seq(1)).fold(fail(_), identity)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 1)
   }
 
   test("Returns an empty sequence if there are no mutants") {
-    val mutations = WeaponRegeX.mutate("a").getOrElse(Nil)
+    val mutations = WeaponRegeX.mutate("a").fold(fail(_), identity)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Returns an empty sequence if the regex is invalid") {
-    val mutations = WeaponRegeX.mutate("*(a|$]").getOrElse(Nil)
+    val mutations = WeaponRegeX.mutate("*(a|$]").fold(fail(_), identity)
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -57,12 +57,6 @@ class WeaponRegeXTest extends munit.FunSuite {
   test("Returns a Left with error message if the regex is invalid") {
     val mutations = WeaponRegeX.mutate("*(a|$]")
 
-    assertEquals(mutations, Left("[Error] Parser: Position 1:1, found \"*(a|$]\""))
-  }
-
-  test("Returns when Parser failed") {
-    val mutations = WeaponRegeX.mutate("(")
-
     assert(clue(mutations) match {
       case Left(msg) => msg.startsWith(ErrorMessage.parserErrorHeader)
       case _         => false

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -1,54 +1,55 @@
 package weaponregex
 
 import weaponregex.constant.ErrorMessage
+import weaponregex.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.model.mutation.Mutant
 import weaponregex.mutator.BuiltinMutators
 
 class WeaponRegeXTest extends munit.FunSuite {
   test("Can mutate without options") {
-    val mutations = WeaponRegeX.mutate("^a").fold(fail(_), identity)
+    val mutations = WeaponRegeX.mutate("^a").getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 2)
   }
 
   test("Can mutate with only mutators as option") {
-    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all).fold(fail(_), identity)
+    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all).getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 2)
   }
 
   test("Can mutate with empty sequence of mutators as option") {
-    val mutations = WeaponRegeX.mutate("^a", Nil).fold(fail(_), identity)
+    val mutations = WeaponRegeX.mutate("^a", Nil).getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Can mutate with only levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(1)).fold(fail(_), identity)
+    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(1)).getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 1)
   }
 
   test("Can mutate with unsupported levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(100, 1000)).fold(fail(_), identity)
+    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(100, 1000)).getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Can mutate with both mutators and levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all, Seq(1)).fold(fail(_), identity)
+    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all, Seq(1)).getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 1)
   }
 
   test("Returns an empty sequence if there are no mutants") {
-    val mutations = WeaponRegeX.mutate("a").fold(fail(_), identity)
+    val mutations = WeaponRegeX.mutate("a").getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)

--- a/core/src/test/scala/weaponregex/extension/EitherExtension.scala
+++ b/core/src/test/scala/weaponregex/extension/EitherExtension.scala
@@ -1,12 +1,12 @@
 package weaponregex.extension
 
 object EitherExtension {
-  implicit class LeftStringEitherTest[+B](either: Either[String, B]) extends munit.FunSuite {
+  implicit class LeftStringEitherTest[+B](either: Either[String, B]) extends munit.Assertions {
 
     /** Get the value of `Right` if this is a `Right`. Otherwise, fail the test with the message from `Left`.
       * @return
       *   The value of `Right`
       */
-    def getOrFail: B = either.fold(fail(_), identity)
+    def getOrFail(implicit loc: munit.Location): B = either.fold(fail(_), identity)
   }
 }

--- a/core/src/test/scala/weaponregex/extension/EitherExtension.scala
+++ b/core/src/test/scala/weaponregex/extension/EitherExtension.scala
@@ -1,0 +1,12 @@
+package weaponregex.extension
+
+object EitherExtension {
+  implicit class LeftStringEitherTest[+B](either: Either[String, B]) extends munit.FunSuite {
+
+    /** Get the value of `Right` if this is a `Right`. Otherwise, fail the test with the message from `Left`.
+      * @return
+      *   The value of `Right`
+      */
+    def getOrFail: B = either.fold(fail(_), identity)
+  }
+}

--- a/core/src/test/scala/weaponregex/mutator/BoundaryMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/BoundaryMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.parser.Parser
 class BoundaryMutatorTest extends munit.FunSuite {
   test("Removes BOL") {
     val pattern = "^abc^def^"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOLRemoval)) map (_.pattern)
 
@@ -22,7 +22,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped BOL") {
     val pattern = "\\^abc"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOLRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -30,7 +30,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Removes EOL") {
     val pattern = "$abc$def$"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOLRemoval)) map (_.pattern)
 
@@ -46,7 +46,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped EOL") {
     val pattern = "abc\\$"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOLRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -54,7 +54,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Changes BOL to BOI") {
     val pattern = "^abc^def^ghi\\^"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOL2BOI)) map (_.pattern)
 
@@ -70,7 +70,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped BOL") {
     val pattern = "\\^abc"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOL2BOI)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -78,7 +78,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Changes EOL to EOI") {
     val pattern = "$abc$def$ghi\\$"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOL2EOI)) map (_.pattern)
 
@@ -94,7 +94,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped EOL") {
     val pattern = "abc\\$"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOL2EOI)) map (_.pattern)
     assertEquals(clue(mutants), Nil)

--- a/core/src/test/scala/weaponregex/mutator/BoundaryMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/BoundaryMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.parser.Parser
 class BoundaryMutatorTest extends munit.FunSuite {
   test("Removes BOL") {
     val pattern = "^abc^def^"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOLRemoval)) map (_.pattern)
 
@@ -22,7 +22,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped BOL") {
     val pattern = "\\^abc"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOLRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -30,7 +30,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Removes EOL") {
     val pattern = "$abc$def$"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOLRemoval)) map (_.pattern)
 
@@ -46,7 +46,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped EOL") {
     val pattern = "abc\\$"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOLRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -54,7 +54,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Changes BOL to BOI") {
     val pattern = "^abc^def^ghi\\^"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOL2BOI)) map (_.pattern)
 
@@ -70,7 +70,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped BOL") {
     val pattern = "\\^abc"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOL2BOI)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -78,7 +78,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Changes EOL to EOI") {
     val pattern = "$abc$def$ghi\\$"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOL2EOI)) map (_.pattern)
 
@@ -94,7 +94,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped EOL") {
     val pattern = "abc\\$"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOL2EOI)) map (_.pattern)
     assertEquals(clue(mutants), Nil)

--- a/core/src/test/scala/weaponregex/mutator/BoundaryMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/BoundaryMutatorTest.scala
@@ -1,12 +1,13 @@
 package weaponregex.mutator
 
+import weaponregex.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.parser.Parser
 
 class BoundaryMutatorTest extends munit.FunSuite {
   test("Removes BOL") {
     val pattern = "^abc^def^"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOLRemoval)) map (_.pattern)
 
@@ -22,7 +23,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped BOL") {
     val pattern = "\\^abc"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOLRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -30,7 +31,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Removes EOL") {
     val pattern = "$abc$def$"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOLRemoval)) map (_.pattern)
 
@@ -46,7 +47,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped EOL") {
     val pattern = "abc\\$"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOLRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -54,7 +55,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Changes BOL to BOI") {
     val pattern = "^abc^def^ghi\\^"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOL2BOI)) map (_.pattern)
 
@@ -70,7 +71,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped BOL") {
     val pattern = "\\^abc"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(BOL2BOI)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -78,7 +79,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Changes EOL to EOI") {
     val pattern = "$abc$def$ghi\\$"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOL2EOI)) map (_.pattern)
 
@@ -94,7 +95,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped EOL") {
     val pattern = "abc\\$"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(EOL2EOI)) map (_.pattern)
     assertEquals(clue(mutants), Nil)

--- a/core/src/test/scala/weaponregex/mutator/CapturingMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/CapturingMutatorTest.scala
@@ -7,7 +7,7 @@ import weaponregex.parser.Parser
 class CapturingMutatorTest extends munit.FunSuite {
   test("Changes capturing group to non-capturing group") {
     val pattern = "(hello)"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
 
@@ -19,7 +19,7 @@ class CapturingMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped capturing groups") {
     val pattern = "\\(hello\\)"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
 
@@ -28,7 +28,7 @@ class CapturingMutatorTest extends munit.FunSuite {
 
   test("Negates lookaround constructs") {
     val pattern = "(?=abc)(?!abc)(?<=abc)(?<!abc)"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(LookaroundNegation)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/CapturingMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/CapturingMutatorTest.scala
@@ -7,7 +7,7 @@ import weaponregex.parser.Parser
 class CapturingMutatorTest extends munit.FunSuite {
   test("Changes capturing group to non-capturing group") {
     val pattern = "(hello)"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
 
@@ -19,7 +19,7 @@ class CapturingMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped capturing groups") {
     val pattern = "\\(hello\\)"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
 
@@ -28,7 +28,7 @@ class CapturingMutatorTest extends munit.FunSuite {
 
   test("Negates lookaround constructs") {
     val pattern = "(?=abc)(?!abc)(?<=abc)(?<!abc)"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(LookaroundNegation)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/CapturingMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/CapturingMutatorTest.scala
@@ -1,5 +1,6 @@
 package weaponregex.mutator
 
+import weaponregex.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.model.mutation.Mutant
 import weaponregex.parser.Parser
@@ -7,7 +8,7 @@ import weaponregex.parser.Parser
 class CapturingMutatorTest extends munit.FunSuite {
   test("Changes capturing group to non-capturing group") {
     val pattern = "(hello)"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
 
@@ -19,7 +20,7 @@ class CapturingMutatorTest extends munit.FunSuite {
 
   test("Does not change escaped capturing groups") {
     val pattern = "\\(hello\\)"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
 
@@ -28,7 +29,7 @@ class CapturingMutatorTest extends munit.FunSuite {
 
   test("Negates lookaround constructs") {
     val pattern = "(?=abc)(?!abc)(?<=abc)(?<!abc)"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(LookaroundNegation)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/CharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/CharClassMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.parser.Parser
 class CharClassMutatorTest extends munit.FunSuite {
   test("Negates Character Classes") {
     val pattern = "[[abc][^abc]]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassNegation)) map (_.pattern)
 
@@ -22,7 +22,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassNegation)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -30,7 +30,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Removes children of Character Classes") {
     val pattern = "[ab0-9[A-Z][cd]]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
 
@@ -50,7 +50,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Removes children of Naked Character Classes") {
     val pattern = "[abc&&def&&[gh]]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
 
@@ -71,7 +71,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (remove children) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -79,7 +79,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class to any char") {
     val pattern = "[abc[0-9]]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassAnyChar)) map (_.pattern)
 
@@ -94,7 +94,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (change to any char) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassAnyChar)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -102,7 +102,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-y][B-Y][1-8]") {
     val pattern = "[b-y][B-Y][1-8]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -130,7 +130,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-y][A-Y][0-8]") {
     val pattern = "[a-y][A-Y][0-8]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -155,7 +155,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-z][B-Z][1-9]") {
     val pattern = "[b-z][B-Z][1-9]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -180,7 +180,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-z][A-Z][0-9]") {
     val pattern = "[a-z][A-Z][0-9]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -202,7 +202,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-b][B-B][1-1]") {
     val pattern = "[b-b][B-B][1-1]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -224,7 +224,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-a][A-A][0-0]") {
     val pattern = "[a-a][A-A][0-0]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -243,7 +243,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [z-z][Z-Z][9-9]") {
     val pattern = "[z-z][Z-Z][9-9]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -262,7 +262,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not modify non alpha numeric ranges") {
     val pattern = "[!-#][a-#][!-z][A-#][!-Z][1-#][!-8]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -270,7 +270,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not modify ranges with letters and digits mixed") {
     val pattern = "[a-8][1-z][A-8][1-Z]"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -278,7 +278,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (modify range) escaped Character Classes") {
     val pattern = "\\[a-z\\]a-z"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)

--- a/core/src/test/scala/weaponregex/mutator/CharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/CharClassMutatorTest.scala
@@ -1,12 +1,13 @@
 package weaponregex.mutator
 
+import weaponregex.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.parser.Parser
 
 class CharClassMutatorTest extends munit.FunSuite {
   test("Negates Character Classes") {
     val pattern = "[[abc][^abc]]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassNegation)) map (_.pattern)
 
@@ -22,7 +23,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassNegation)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -30,7 +31,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Removes children of Character Classes") {
     val pattern = "[ab0-9[A-Z][cd]]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
 
@@ -50,7 +51,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Removes children of Naked Character Classes") {
     val pattern = "[abc&&def&&[gh]]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
 
@@ -71,7 +72,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (remove children) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -79,7 +80,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class to any char") {
     val pattern = "[abc[0-9]]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassAnyChar)) map (_.pattern)
 
@@ -94,7 +95,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (change to any char) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassAnyChar)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -102,7 +103,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-y][B-Y][1-8]") {
     val pattern = "[b-y][B-Y][1-8]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -130,7 +131,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-y][A-Y][0-8]") {
     val pattern = "[a-y][A-Y][0-8]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -155,7 +156,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-z][B-Z][1-9]") {
     val pattern = "[b-z][B-Z][1-9]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -180,7 +181,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-z][A-Z][0-9]") {
     val pattern = "[a-z][A-Z][0-9]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -202,7 +203,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-b][B-B][1-1]") {
     val pattern = "[b-b][B-B][1-1]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -224,7 +225,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-a][A-A][0-0]") {
     val pattern = "[a-a][A-A][0-0]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -243,7 +244,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [z-z][Z-Z][9-9]") {
     val pattern = "[z-z][Z-Z][9-9]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -262,7 +263,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not modify non alpha numeric ranges") {
     val pattern = "[!-#][a-#][!-z][A-#][!-Z][1-#][!-8]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -270,7 +271,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not modify ranges with letters and digits mixed") {
     val pattern = "[a-8][1-z][A-8][1-Z]"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -278,7 +279,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (modify range) escaped Character Classes") {
     val pattern = "\\[a-z\\]a-z"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)

--- a/core/src/test/scala/weaponregex/mutator/CharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/CharClassMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.parser.Parser
 class CharClassMutatorTest extends munit.FunSuite {
   test("Negates Character Classes") {
     val pattern = "[[abc][^abc]]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassNegation)) map (_.pattern)
 
@@ -22,7 +22,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassNegation)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -30,7 +30,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Removes children of Character Classes") {
     val pattern = "[ab0-9[A-Z][cd]]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
 
@@ -50,7 +50,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Removes children of Naked Character Classes") {
     val pattern = "[abc&&def&&[gh]]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
 
@@ -71,7 +71,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (remove children) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -79,7 +79,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class to any char") {
     val pattern = "[abc[0-9]]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassAnyChar)) map (_.pattern)
 
@@ -94,7 +94,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (change to any char) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassAnyChar)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -102,7 +102,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-y][B-Y][1-8]") {
     val pattern = "[b-y][B-Y][1-8]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -130,7 +130,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-y][A-Y][0-8]") {
     val pattern = "[a-y][A-Y][0-8]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -155,7 +155,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-z][B-Z][1-9]") {
     val pattern = "[b-z][B-Z][1-9]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -180,7 +180,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-z][A-Z][0-9]") {
     val pattern = "[a-z][A-Z][0-9]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -202,7 +202,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [b-b][B-B][1-1]") {
     val pattern = "[b-b][B-B][1-1]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -224,7 +224,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [a-a][A-A][0-0]") {
     val pattern = "[a-a][A-A][0-0]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -243,7 +243,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Character Class Modify Range [z-z][Z-Z][9-9]") {
     val pattern = "[z-z][Z-Z][9-9]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
 
@@ -262,7 +262,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not modify non alpha numeric ranges") {
     val pattern = "[!-#][a-#][!-z][A-#][!-Z][1-#][!-8]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -270,7 +270,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not modify ranges with letters and digits mixed") {
     val pattern = "[a-8][1-z][A-8][1-Z]"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -278,7 +278,7 @@ class CharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (modify range) escaped Character Classes") {
     val pattern = "\\[a-z\\]a-z"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)

--- a/core/src/test/scala/weaponregex/mutator/PredefCharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/PredefCharClassMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.parser.Parser
 class PredefCharClassMutatorTest extends munit.FunSuite {
   test("Negates Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNegation)) map (_.pattern)
 
@@ -25,7 +25,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (negate) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNegation)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -33,7 +33,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Nullifies Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNullification)) map (_.pattern)
 
@@ -52,7 +52,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (nullify) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNullification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -60,7 +60,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Changes Predefined Character Class to Any Char") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassAnyChar)) map (_.pattern)
 
@@ -79,7 +79,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (change) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassAnyChar)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -87,7 +87,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Negates POSIX Character Class") {
     val pattern = """\p{Alpha}\P{Alpha}"""
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(POSIXCharClassNegation)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/PredefCharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/PredefCharClassMutatorTest.scala
@@ -1,12 +1,13 @@
 package weaponregex.mutator
 
+import weaponregex.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.parser.Parser
 
 class PredefCharClassMutatorTest extends munit.FunSuite {
   test("Negates Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNegation)) map (_.pattern)
 
@@ -25,7 +26,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (negate) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNegation)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -33,7 +34,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Nullifies Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNullification)) map (_.pattern)
 
@@ -52,7 +53,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (nullify) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNullification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -60,7 +61,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Changes Predefined Character Class to Any Char") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassAnyChar)) map (_.pattern)
 
@@ -79,7 +80,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (change) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassAnyChar)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -87,7 +88,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Negates POSIX Character Class") {
     val pattern = """\p{Alpha}\P{Alpha}"""
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(POSIXCharClassNegation)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/PredefCharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/PredefCharClassMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.parser.Parser
 class PredefCharClassMutatorTest extends munit.FunSuite {
   test("Negates Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNegation)) map (_.pattern)
 
@@ -25,7 +25,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (negate) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNegation)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -33,7 +33,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Nullifies Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNullification)) map (_.pattern)
 
@@ -52,7 +52,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (nullify) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNullification)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -60,7 +60,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Changes Predefined Character Class to Any Char") {
     val pattern = """\w\W\d\D\s\S"""
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassAnyChar)) map (_.pattern)
 
@@ -79,7 +79,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Does not mutate (change) similar characters") {
     val pattern = "wWdDsS"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassAnyChar)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -87,7 +87,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
 
   test("Negates POSIX Character Class") {
     val pattern = """\p{Alpha}\P{Alpha}"""
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(POSIXCharClassNegation)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/QuantifierMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/QuantifierMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.parser.Parser
 class QuantifierMutatorTest extends munit.FunSuite {
   test("Removes greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}g"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -25,7 +25,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped greedy quantifiers") {
     val pattern = """a\?b\*c\+d\{1\}e\{1,\}f\{1,2\}g"""
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -33,7 +33,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Removes reluctant quantifier") {
     val pattern = "a??b*?c+?d{1}?e{1,}?f{1,2}?g"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -52,7 +52,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped greedy quantifiers") {
     val pattern = """a\?\?b\*\?c\+\?d\{1\}\?e\{1,\}\?f\{1,2\}\?g"""
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -60,7 +60,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Removes possessive quantifier") {
     val pattern = "a?+b*+c++d{1}+e{1,}+f{1,2}+"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -79,7 +79,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped possessive quantifiers") {
     val pattern = """a\?\+b\*\+c\+\+d\{1\}\+e\{1,\}\+f\{1,2\}\+g"""
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -87,7 +87,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes quantifier {n}") {
     val pattern = "a{1}"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNChange)) map (_.pattern)
 
@@ -102,7 +102,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies quantifier {n,}") {
     val pattern = "a{0,}b{1,}"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreModification)) map (_.pattern)
 
@@ -118,7 +118,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNOrMoreModification Does not mutate quantifier {n} and {n,m}") {
     val pattern = "a{3}b{4,9}"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreModification)) map (_.pattern)
 
@@ -127,7 +127,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes quantifier {n,}") {
     val pattern = "a{1,}"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreChange)) map (_.pattern)
 
@@ -139,7 +139,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNOrMoreChange Does not mutate quantifier {n} and {n,m}") {
     val pattern = "a{3}b{4,9}"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreChange)) map (_.pattern)
 
@@ -148,7 +148,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies quantifier {n,m}") {
     val pattern = "a{0,0}b{0,1}c{1,2}"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNMModification)) map (_.pattern)
 
@@ -169,7 +169,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNMModification Does not mutate quantifier {n} and {n,}") {
     val pattern = "a{3}b{4,}"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNMModification)) map (_.pattern)
 
@@ -178,7 +178,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies short quantifier") {
     val pattern = "a?b*c+"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierShortModification)) map (_.pattern)
 
@@ -197,7 +197,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes short quantifier") {
     val pattern = "a*b+"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierShortChange)) map (_.pattern)
 
@@ -212,7 +212,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Adds reluctant to greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}"
-    val parsedTree = Parser(pattern).get
+    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierReluctantAddition)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/QuantifierMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/QuantifierMutatorTest.scala
@@ -6,7 +6,7 @@ import weaponregex.parser.Parser
 class QuantifierMutatorTest extends munit.FunSuite {
   test("Removes greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}g"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -25,7 +25,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped greedy quantifiers") {
     val pattern = """a\?b\*c\+d\{1\}e\{1,\}f\{1,2\}g"""
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -33,7 +33,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Removes reluctant quantifier") {
     val pattern = "a??b*?c+?d{1}?e{1,}?f{1,2}?g"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -52,7 +52,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped greedy quantifiers") {
     val pattern = """a\?\?b\*\?c\+\?d\{1\}\?e\{1,\}\?f\{1,2\}\?g"""
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -60,7 +60,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Removes possessive quantifier") {
     val pattern = "a?+b*+c++d{1}+e{1,}+f{1,2}+"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -79,7 +79,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped possessive quantifiers") {
     val pattern = """a\?\+b\*\+c\+\+d\{1\}\+e\{1,\}\+f\{1,2\}\+g"""
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -87,7 +87,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes quantifier {n}") {
     val pattern = "a{1}"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNChange)) map (_.pattern)
 
@@ -102,7 +102,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies quantifier {n,}") {
     val pattern = "a{0,}b{1,}"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreModification)) map (_.pattern)
 
@@ -118,7 +118,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNOrMoreModification Does not mutate quantifier {n} and {n,m}") {
     val pattern = "a{3}b{4,9}"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreModification)) map (_.pattern)
 
@@ -127,7 +127,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes quantifier {n,}") {
     val pattern = "a{1,}"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreChange)) map (_.pattern)
 
@@ -139,7 +139,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNOrMoreChange Does not mutate quantifier {n} and {n,m}") {
     val pattern = "a{3}b{4,9}"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreChange)) map (_.pattern)
 
@@ -148,7 +148,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies quantifier {n,m}") {
     val pattern = "a{0,0}b{0,1}c{1,2}"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNMModification)) map (_.pattern)
 
@@ -169,7 +169,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNMModification Does not mutate quantifier {n} and {n,}") {
     val pattern = "a{3}b{4,}"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNMModification)) map (_.pattern)
 
@@ -178,7 +178,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies short quantifier") {
     val pattern = "a?b*c+"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierShortModification)) map (_.pattern)
 
@@ -197,7 +197,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes short quantifier") {
     val pattern = "a*b+"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierShortChange)) map (_.pattern)
 
@@ -212,7 +212,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Adds reluctant to greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}"
-    val parsedTree = Parser(pattern).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern).fold(fail(_), identity)
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierReluctantAddition)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/QuantifierMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/QuantifierMutatorTest.scala
@@ -1,12 +1,13 @@
 package weaponregex.mutator
 
+import weaponregex.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.parser.Parser
 
 class QuantifierMutatorTest extends munit.FunSuite {
   test("Removes greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}g"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -25,7 +26,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped greedy quantifiers") {
     val pattern = """a\?b\*c\+d\{1\}e\{1,\}f\{1,2\}g"""
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -33,7 +34,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Removes reluctant quantifier") {
     val pattern = "a??b*?c+?d{1}?e{1,}?f{1,2}?g"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -52,7 +53,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped greedy quantifiers") {
     val pattern = """a\?\?b\*\?c\+\?d\{1\}\?e\{1,\}\?f\{1,2\}\?g"""
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -60,7 +61,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Removes possessive quantifier") {
     val pattern = "a?+b*+c++d{1}+e{1,}+f{1,2}+"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
 
@@ -79,7 +80,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Does not remove escaped possessive quantifiers") {
     val pattern = """a\?\+b\*\+c\+\+d\{1\}\+e\{1,\}\+f\{1,2\}\+g"""
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
     assertEquals(clue(mutants), Nil)
@@ -87,7 +88,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes quantifier {n}") {
     val pattern = "a{1}"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNChange)) map (_.pattern)
 
@@ -102,7 +103,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies quantifier {n,}") {
     val pattern = "a{0,}b{1,}"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreModification)) map (_.pattern)
 
@@ -118,7 +119,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNOrMoreModification Does not mutate quantifier {n} and {n,m}") {
     val pattern = "a{3}b{4,9}"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreModification)) map (_.pattern)
 
@@ -127,7 +128,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes quantifier {n,}") {
     val pattern = "a{1,}"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreChange)) map (_.pattern)
 
@@ -139,7 +140,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNOrMoreChange Does not mutate quantifier {n} and {n,m}") {
     val pattern = "a{3}b{4,9}"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreChange)) map (_.pattern)
 
@@ -148,7 +149,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies quantifier {n,m}") {
     val pattern = "a{0,0}b{0,1}c{1,2}"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNMModification)) map (_.pattern)
 
@@ -169,7 +170,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("QuantifierNMModification Does not mutate quantifier {n} and {n,}") {
     val pattern = "a{3}b{4,}"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNMModification)) map (_.pattern)
 
@@ -178,7 +179,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Modifies short quantifier") {
     val pattern = "a?b*c+"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierShortModification)) map (_.pattern)
 
@@ -197,7 +198,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Changes short quantifier") {
     val pattern = "a*b+"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierShortChange)) map (_.pattern)
 
@@ -212,7 +213,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
 
   test("Adds reluctant to greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}"
-    val parsedTree = Parser(pattern).fold(fail(_), identity)
+    val parsedTree = Parser(pattern).getOrFail
 
     val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierReluctantAddition)) map (_.pattern)
 

--- a/core/src/test/scala/weaponregex/mutator/RegexTreeMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/RegexTreeMutatorTest.scala
@@ -7,7 +7,7 @@ import weaponregex.parser.Parser
 class RegexTreeMutatorTest extends munit.FunSuite {
 
   val tree: RegexTree =
-    Parser("""^(a*|b+(?=c)|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$""").getOrElse(fail("Failed to parse"))
+    Parser("""^(a*|b+(?=c)|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$""").fold(fail(_), identity)
 
   test("Filters mutators with level 1") {
     val levels = Seq(1)

--- a/core/src/test/scala/weaponregex/mutator/RegexTreeMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/RegexTreeMutatorTest.scala
@@ -1,5 +1,6 @@
 package weaponregex.mutator
 
+import weaponregex.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.model.regextree.RegexTree
 import weaponregex.parser.Parser
@@ -7,7 +8,7 @@ import weaponregex.parser.Parser
 class RegexTreeMutatorTest extends munit.FunSuite {
 
   val tree: RegexTree =
-    Parser("""^(a*|b+(?=c)|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$""").fold(fail(_), identity)
+    Parser("""^(a*|b+(?=c)|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$""").getOrFail
 
   test("Filters mutators with level 1") {
     val levels = Seq(1)

--- a/core/src/test/scala/weaponregex/mutator/RegexTreeMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/RegexTreeMutatorTest.scala
@@ -6,7 +6,8 @@ import weaponregex.parser.Parser
 
 class RegexTreeMutatorTest extends munit.FunSuite {
 
-  val tree: RegexTree = Parser("""^(a*|b+(?=c)|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$""").get
+  val tree: RegexTree =
+    Parser("""^(a*|b+(?=c)|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$""").getOrElse(fail("Failed to parse"))
 
   test("Filters mutators with level 1") {
     val levels = Seq(1)

--- a/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJSTest.scala
@@ -15,7 +15,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Not parse `\A\G\z\Z` as boundary metacharacters""") {
     val pattern = """\A\G\z\Z"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Node]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Node]
 
     parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[Boundary]))
 
@@ -24,7 +24,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse empty positive character class with characters") {
     val pattern = "[]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     assert(clue(parsedTree.children).isEmpty)
 
@@ -33,7 +33,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse negative character class with characters") {
     val pattern = "[^]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     assert(!parsedTree.isPositive)
     assert(clue(parsedTree.children).isEmpty)
@@ -43,7 +43,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `[` as character inside a character class") {
     val pattern = "[[]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     assert(clue(parsedTree.children.head) match {
       case Character('[', _) => true
@@ -55,7 +55,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Not parse `\a\e` as escape characters""") {
     val pattern = """\a\e"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[MetaChar]))
 
@@ -64,7 +64,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-hexadecimal value `\\xGG`  without the Unicode flag") {
     val pattern = "\\xGG"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assertEquals(parsedTree.children.length, 3)
 
@@ -73,7 +73,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-unicode value `\\uGGGG` without the Unicode flag") {
     val pattern = "\\uGGGG"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assertEquals(parsedTree.children.length, 5)
 
@@ -82,7 +82,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\u20` as character quotation without the Unicode flag") {
     val pattern = "\\u20"
-    val parsedTree = Parser(pattern, None, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, None, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case QuoteChar('u', _) => true
@@ -94,7 +94,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\u{20}` as quantifier without the Unicode flag") {
     val pattern = "\\u{20}"
-    val parsedTree = Parser(pattern, None, parserFlavor).get.to[Quantifier]
+    val parsedTree = Parser(pattern, None, parserFlavor).getOrElse(fail("Failed to parse")).to[Quantifier]
 
     assert(clue(parsedTree) match {
       case Quantifier(QuoteChar('u', _), 20, 20, _, GreedyQuantifier, true) => true
@@ -106,7 +106,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\x{20}` as quantifier without the Unicode flag") {
     val pattern = "\\x{20}"
-    val parsedTree = Parser(pattern, None, parserFlavor).get.to[Quantifier]
+    val parsedTree = Parser(pattern, None, parserFlavor).getOrElse(fail("Failed to parse")).to[Quantifier]
 
     assert(clue(parsedTree) match {
       case Quantifier(QuoteChar('x', _), 20, 20, _, GreedyQuantifier, true) => true
@@ -118,7 +118,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\u{FFFFFF}` as character quotation without the Unicode flag") {
     val pattern = "\\u{FFFFFF}"
-    val parsedTree = Parser(pattern, None, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, None, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case QuoteChar('u', _) => true
@@ -130,7 +130,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\u{20}` as Unicode character with the Unicode flag") {
     val pattern = "\\u{20}"
-    val parsedTree = Parser(pattern, Some("u"), parserFlavor).get.to[MetaChar]
+    val parsedTree = Parser(pattern, Some("u"), parserFlavor).getOrElse(fail("Failed to parse")).to[MetaChar]
 
     assertEquals(parsedTree.metaChar, "u{20}")
 
@@ -154,7 +154,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse character class with POSIX character classes with the Unicode flag") {
     val pattern = """[\p{Alpha}\P{hello_World_0123}]"""
-    val parsedTree = Parser(pattern, Some("u"), parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, Some("u"), parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     assert(clue(parsedTree.children.head) match {
       case POSIXCharClass("Alpha", _, true) => true
@@ -170,7 +170,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse POSIX character classes with the Unicode flag") {
     val pattern = """\p{Alpha}\P{hello_World_0123}"""
-    val parsedTree = Parser(pattern, Some("u"), parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, Some("u"), parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case POSIXCharClass("Alpha", _, true) => true
@@ -186,7 +186,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\p{Alpha}` as a character quotation in a character class without the Unicode flag") {
     val pattern = """[\p{Alpha}]"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     assert(clue(parsedTree.children.head) match {
       case QuoteChar('p', _) => true
@@ -198,7 +198,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `\\p{Alpha}` as a character quotation without the Unicode flag") {
     val pattern = """\p{Alpha}"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case QuoteChar('p', _) => true
@@ -210,7 +210,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Not parse `\h\H\V` as predefined character class""") {
     val pattern = """\h\H\V"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     parsedTree.children foreach (child => assert(!clue(child).isInstanceOf[PredefinedCharClass]))
 
@@ -274,7 +274,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Parse `\Q\E` as character quotes""") {
     val pattern = """stuff\Q$hit\Emorestuff"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case QuoteChar('Q', _) => true
@@ -290,7 +290,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("""Parse `\Q` as a character quote""") {
     val pattern = """stuff\Q$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case QuoteChar('Q', _) => true
@@ -303,7 +303,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
   test("Parse syntax characters escape with the Unicode flag") {
     val syntaxChars = """^$\.*+?()[]{}|/"""
     val pattern = "\\" + syntaxChars.mkString("\\")
-    val parsedTree = Parser(pattern, Some("u"), parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, Some("u"), parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     syntaxChars zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -332,7 +332,7 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
 
   test("Parse `{`") {
     val pattern = "{"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Character]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Character]
 
     assertEquals(parsedTree.char, '{')
   }

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -25,7 +25,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse character class with nested character classes") {
     val pattern = "[[a-z][^A-Z0-9][01234]]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     parsedTree.children foreach (child => assert(child.isInstanceOf[CharacterClass], clue = parsedTree.children))
 
@@ -35,7 +35,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
   test("Parse character class with simple intersection") {
     val subClasses = Seq("abc", "def", "ghi")
     val pattern = subClasses.mkString("[", "&&", "]")
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Node]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Node]
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     assertEquals(parsedTree.children.length, 1)
@@ -58,7 +58,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse character class with complex intersection") {
     val pattern = """[a-z&&&[a&&b]]"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case CharacterClass(
@@ -132,7 +132,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse character class with POSIX character classes") {
     val pattern = """[\p{Alpha}\P{hello_World_0123}]"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     assert(clue(parsedTree.children.head) match {
       case POSIXCharClass("Alpha", _, true) => true
@@ -148,7 +148,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse POSIX character classes") {
     val pattern = """\p{Alpha}\P{hello_World_0123}"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case POSIXCharClass("Alpha", _, true) => true
@@ -164,7 +164,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group i-i") {
     val pattern = "(?idmsuxU-idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -177,7 +177,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group i-") {
     val pattern = "(?idmsuxU-)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -190,7 +190,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group -i") {
     val pattern = "(?-idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -203,7 +203,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group -") {
     val pattern = "(?-)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -216,7 +216,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group i") {
     val pattern = "(?idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, false, offFlags, _), _) =>
@@ -229,7 +229,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags i-i") {
     val pattern = "(?idmsux-idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -242,7 +242,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags i-") {
     val pattern = "(?idmsux-:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -255,7 +255,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags -i") {
     val pattern = "(?-idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -268,7 +268,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags -") {
     val pattern = "(?-:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -281,7 +281,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags i") {
     val pattern = "(?idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, false, offFlags, _), _: Concat, _) =>
@@ -294,7 +294,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse independent non-capturing group") {
     val pattern = "(?>hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case AtomicGroup(_: Concat, _) => true
@@ -306,7 +306,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse numbered reference") {
     val pattern = """\123"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[NumberReference]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[NumberReference]
 
     assertEquals(parsedTree.num, 123)
 
@@ -315,7 +315,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse long quote with end") {
     val pattern = """stuff\Q$hit\Emorestuff"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case Quote("$hit", true, _) => true
@@ -327,7 +327,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse long quote without end") {
     val pattern = """stuff\Q$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case Quote("$hit", false, _) => true

--- a/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserJVMTest.scala
@@ -25,7 +25,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse character class with nested character classes") {
     val pattern = "[[a-z][^A-Z0-9][01234]]"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[CharacterClass]
 
     parsedTree.children foreach (child => assert(child.isInstanceOf[CharacterClass], clue = parsedTree.children))
 
@@ -35,7 +35,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
   test("Parse character class with simple intersection") {
     val subClasses = Seq("abc", "def", "ghi")
     val pattern = subClasses.mkString("[", "&&", "]")
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Node]
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Node]
 
     assert(clue(parsedTree).isInstanceOf[CharacterClass])
     assertEquals(parsedTree.children.length, 1)
@@ -58,7 +58,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse character class with complex intersection") {
     val pattern = """[a-z&&&[a&&b]]"""
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case CharacterClass(
@@ -132,7 +132,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse character class with POSIX character classes") {
     val pattern = """[\p{Alpha}\P{hello_World_0123}]"""
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[CharacterClass]
 
     assert(clue(parsedTree.children.head) match {
       case POSIXCharClass("Alpha", _, true) => true
@@ -148,7 +148,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse POSIX character classes") {
     val pattern = """\p{Alpha}\P{hello_World_0123}"""
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case POSIXCharClass("Alpha", _, true) => true
@@ -164,7 +164,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group i-i") {
     val pattern = "(?idmsuxU-idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -177,7 +177,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group i-") {
     val pattern = "(?idmsuxU-)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -190,7 +190,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group -i") {
     val pattern = "(?-idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -203,7 +203,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group -") {
     val pattern = "(?-)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, true, offFlags, _), _) =>
@@ -216,7 +216,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse flag toggle group i") {
     val pattern = "(?idmsuxU)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagToggleGroup(FlagToggle(onFlags, false, offFlags, _), _) =>
@@ -229,7 +229,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags i-i") {
     val pattern = "(?idmsux-idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -242,7 +242,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags i-") {
     val pattern = "(?idmsux-:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -255,7 +255,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags -i") {
     val pattern = "(?-idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -268,7 +268,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags -") {
     val pattern = "(?-:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, true, offFlags, _), _: Concat, _) =>
@@ -281,7 +281,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse non-capturing group with flags i") {
     val pattern = "(?idmsux:hello)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case FlagNCGroup(FlagToggle(onFlags, false, offFlags, _), _: Concat, _) =>
@@ -294,7 +294,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse independent non-capturing group") {
     val pattern = "(?>hello)"
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
 
     assert(clue(parsedTree) match {
       case AtomicGroup(_: Concat, _) => true
@@ -306,7 +306,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse numbered reference") {
     val pattern = """\123"""
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[NumberReference]
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[NumberReference]
 
     assertEquals(parsedTree.num, 123)
 
@@ -315,7 +315,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse long quote with end") {
     val pattern = """stuff\Q$hit\Emorestuff"""
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case Quote("$hit", true, _) => true
@@ -327,7 +327,7 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
 
   test("Parse long quote without end") {
     val pattern = """stuff\Q$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case Quote("$hit", false, _) => true

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -6,7 +6,6 @@ import weaponregex.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.model.regextree.*
 
 import scala.reflect.ClassTag
-import scala.util.Failure
 
 trait ParserTest {
   this: munit.FunSuite =>
@@ -27,14 +26,14 @@ trait ParserTest {
     val parsedTree = Parser(pattern, flags, parserFlavor)
 
     assert(clue(parsedTree) match {
-      case Failure(exception: RuntimeException) => exception.getMessage.startsWith(ErrorMessage.parserErrorHeader)
-      case _                                    => false
+      case Left(msg) => msg.startsWith(ErrorMessage.parserErrorHeader)
+      case _         => false
     })
   }
 
   test("Parse concat of characters") {
     val pattern = "hello"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     pattern zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -48,7 +47,7 @@ trait ParserTest {
 
   test("Parse `}` character next to long quantifier") {
     val pattern = "a{1}}"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(parsedTree.children.head.isInstanceOf[Quantifier])
     assert(parsedTree.children.last match {
@@ -61,7 +60,7 @@ trait ParserTest {
 
   test("Parse `]` character next to character class") {
     val pattern = "[abc]]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(parsedTree.children.head.isInstanceOf[CharacterClass])
     assert(parsedTree.children.last match {
@@ -74,7 +73,7 @@ trait ParserTest {
 
   test("Parse or of characters") {
     val pattern = "h|e|l|l|o"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Or]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Or]
 
     pattern.replace("|", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -88,7 +87,7 @@ trait ParserTest {
 
   test("Parse or of characters with null children") {
     val pattern = "|h|e||l|||l|o|"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Or]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Or]
 
     assert(clue(parsedTree.children) match {
       case Seq(
@@ -112,7 +111,7 @@ trait ParserTest {
 
   test("Parse BOL and EOL") {
     val pattern = "^hello$"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
     assert(clue(parsedTree.children.head).isInstanceOf[BOL])
     assert(clue(parsedTree.children.last).isInstanceOf[EOL])
 
@@ -121,7 +120,7 @@ trait ParserTest {
 
   test("Parse boundary metacharacters") {
     val pattern = boundaryMetacharacters
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     pattern.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -141,7 +140,7 @@ trait ParserTest {
         |a
         |a
         |a""".stripMargin
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     parsedTree.children filter {
       case Character('a', _) => true
@@ -155,7 +154,7 @@ trait ParserTest {
 
   test("Parse positive character class with characters") {
     val pattern = "[abc]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     pattern.init.tail zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -169,7 +168,7 @@ trait ParserTest {
 
   test("Parse negative character class with characters") {
     val pattern = "[^abc]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Node]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Node]
 
     assert(parsedTree match {
       case CharacterClass(_, _, false) => true
@@ -191,7 +190,7 @@ trait ParserTest {
     val ranges = Seq("az", "AZ", "09", "$%")
     // Generate pattern from these ranges
     val pattern = "[" + ranges.map(r => s"${r.head}-${r.last}").mkString + "]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     ranges zip parsedTree.children foreach { case (range, child) =>
       assert(clue(child) match {
@@ -205,7 +204,7 @@ trait ParserTest {
 
   test("Parse character class with predefined character classes") {
     val pattern = s"[$charClassPredefCharClasses]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     pattern.init.tail.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -219,7 +218,7 @@ trait ParserTest {
 
   test("Parse character class with quotes") {
     val pattern = """[\]]"""
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case CharacterClass(nodes, _, true) => nodes.head.isInstanceOf[QuoteChar]
@@ -231,7 +230,7 @@ trait ParserTest {
 
   test("Parse character class with metacharacters") {
     val pattern = """[\\\t\n\r\f]"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     // A backslash is added back in to represent the backslash in the pattern
     """\""" + pattern.tail.init.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
@@ -246,7 +245,7 @@ trait ParserTest {
 
   test("Parse character class with special characters") {
     val pattern = s"[$charClassSpecialChars]"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[CharacterClass]
 
     pattern.tail.init zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -260,7 +259,7 @@ trait ParserTest {
 
   test("Parse escape characters") {
     val pattern = escapeCharacters
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     // A backslash is added back in to represent the backslash in the pattern
     """\""" + pattern.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
@@ -276,7 +275,7 @@ trait ParserTest {
   test("Parse control characters") {
     val controlChars: Seq[Char] = ('a' to 'z') ++ ('A' to 'Z')
     val pattern = (controlChars map ("""\c""" + _)).mkString
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     controlChars zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -290,7 +289,7 @@ trait ParserTest {
 
   test("Parse hexadecimal characters") {
     val pattern = hexCharacters
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     pattern.split("""\\""").tail zip parsedTree.children foreach { case (str, child) =>
       assert(clue(child) match {
@@ -304,7 +303,7 @@ trait ParserTest {
 
   test("Parse octal characters") {
     val pattern = octCharacters
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     pattern.split("""\\""").tail zip parsedTree.children foreach { case (str, child) =>
       assert(clue(child) match {
@@ -318,7 +317,7 @@ trait ParserTest {
 
   test("Parse predefined character class") {
     val pattern = predefCharClasses
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     pattern.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -333,7 +332,7 @@ trait ParserTest {
 
   test("Parse short greedy quantifiers") {
     val pattern = "a*b+c?"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
     assert(clue(parsedTree.children(1)).isInstanceOf[OneOrMore])
@@ -353,7 +352,7 @@ trait ParserTest {
 
   test("Parse short reluctant quantifiers") {
     val pattern = "a*?b+?c??"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
     assert(clue(parsedTree.children(1)).isInstanceOf[OneOrMore])
@@ -373,7 +372,7 @@ trait ParserTest {
 
   test("Parse short possessive quantifiers") {
     val pattern = "a*+b++c?+"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
     assert(clue(parsedTree.children(1)).isInstanceOf[OneOrMore])
@@ -393,7 +392,7 @@ trait ParserTest {
 
   test("Parse long greedy quantifiers") {
     val pattern = "a{1}b{1,}c{1,2}"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(parsedTree.children(0) match {
       case Quantifier(Character('a', _), 1, 1, _, GreedyQuantifier, true) => true
@@ -415,7 +414,7 @@ trait ParserTest {
 
   test("Parse long reluctant quantifiers") {
     val pattern = "a{1}?b{1,}?c{1,2}?"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(parsedTree.children(0) match {
       case Quantifier(Character('a', _), 1, 1, _, ReluctantQuantifier, true) => true
@@ -437,7 +436,7 @@ trait ParserTest {
 
   test("Parse long possessive quantifiers") {
     val pattern = "a{1}+b{1,}+c{1,2}+"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(parsedTree.children(0) match {
       case Quantifier(Character('a', _), 1, 1, _, PossessiveQuantifier, true) => true
@@ -464,7 +463,7 @@ trait ParserTest {
 
   test("Parse capturing group") {
     val pattern = "(hello)(world)"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     parsedTree.children foreach (child =>
       assert(
@@ -481,7 +480,7 @@ trait ParserTest {
 
   test("Parse nested capturing group") {
     val pattern = "(hello(world))"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case Group(Concat(nodes, _), true, _) =>
@@ -498,7 +497,7 @@ trait ParserTest {
 
   test("Parse named capturing group") {
     val pattern = "(?<groupName1>hello)(?<GroupName2>world)"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case NamedGroup(_: Concat, name, _) => name == "groupName1"
@@ -514,7 +513,7 @@ trait ParserTest {
 
   test("Parse nested named capturing group") {
     val pattern = "(?<groupName1>hello(?<GroupName2>world))"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case NamedGroup(Concat(nodes, _), "groupName1", _) =>
@@ -531,7 +530,7 @@ trait ParserTest {
 
   test("Parse non-capturing group") {
     val pattern = "(?:hello)(?:world)"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     parsedTree.children foreach (child =>
       assert(
@@ -548,7 +547,7 @@ trait ParserTest {
 
   test("Parse nested non-capturing group") {
     val pattern = "(?:hello(?:world))"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case Group(Concat(nodes, _), false, _) =>
@@ -565,7 +564,7 @@ trait ParserTest {
 
   test("Parse positive lookahead") {
     val pattern = "(?=hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, true, true, _) => true
@@ -577,7 +576,7 @@ trait ParserTest {
 
   test("Parse negative lookahead") {
     val pattern = "(?!hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, false, true, _) => true
@@ -589,7 +588,7 @@ trait ParserTest {
 
   test("Parse positive lookbehind") {
     val pattern = "(?<=hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse"))
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, true, false, _) => true
@@ -601,7 +600,7 @@ trait ParserTest {
 
   test("Parse negative lookbehind") {
     val pattern = "(?<!hello)"
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Lookaround]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Lookaround]
 
     assert(parsedTree.expr.isInstanceOf[Concat])
     assert(!clue(parsedTree).isPositive)
@@ -612,7 +611,7 @@ trait ParserTest {
 
   test("Parse named reference") {
     val pattern = """\k<name1>"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[NameReference]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[NameReference]
 
     assertEquals(parsedTree.name, "name1")
 
@@ -621,7 +620,7 @@ trait ParserTest {
 
   test("Parse character quote") {
     val pattern = """stuff\$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).get.to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrElse(fail("Failed to parse")).to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case QuoteChar('$', _) => true

--- a/core/src/test/scala/weaponregex/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/parser/ParserTest.scala
@@ -2,6 +2,7 @@ package weaponregex.parser
 
 import munit.Location
 import weaponregex.constant.ErrorMessage
+import weaponregex.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.model.regextree.*
 
@@ -33,7 +34,7 @@ trait ParserTest {
 
   test("Parse concat of characters") {
     val pattern = "hello"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     pattern zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -47,7 +48,7 @@ trait ParserTest {
 
   test("Parse `}` character next to long quantifier") {
     val pattern = "a{1}}"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(parsedTree.children.head.isInstanceOf[Quantifier])
     assert(parsedTree.children.last match {
@@ -60,7 +61,7 @@ trait ParserTest {
 
   test("Parse `]` character next to character class") {
     val pattern = "[abc]]"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(parsedTree.children.head.isInstanceOf[CharacterClass])
     assert(parsedTree.children.last match {
@@ -73,7 +74,7 @@ trait ParserTest {
 
   test("Parse or of characters") {
     val pattern = "h|e|l|l|o"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Or]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Or]
 
     pattern.replace("|", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -87,7 +88,7 @@ trait ParserTest {
 
   test("Parse or of characters with null children") {
     val pattern = "|h|e||l|||l|o|"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Or]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Or]
 
     assert(clue(parsedTree.children) match {
       case Seq(
@@ -111,7 +112,7 @@ trait ParserTest {
 
   test("Parse BOL and EOL") {
     val pattern = "^hello$"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
     assert(clue(parsedTree.children.head).isInstanceOf[BOL])
     assert(clue(parsedTree.children.last).isInstanceOf[EOL])
 
@@ -120,7 +121,7 @@ trait ParserTest {
 
   test("Parse boundary metacharacters") {
     val pattern = boundaryMetacharacters
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     pattern.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -140,7 +141,7 @@ trait ParserTest {
         |a
         |a
         |a""".stripMargin
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     parsedTree.children filter {
       case Character('a', _) => true
@@ -154,7 +155,7 @@ trait ParserTest {
 
   test("Parse positive character class with characters") {
     val pattern = "[abc]"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[CharacterClass]
 
     pattern.init.tail zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -168,7 +169,7 @@ trait ParserTest {
 
   test("Parse negative character class with characters") {
     val pattern = "[^abc]"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Node]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Node]
 
     assert(parsedTree match {
       case CharacterClass(_, _, false) => true
@@ -190,7 +191,7 @@ trait ParserTest {
     val ranges = Seq("az", "AZ", "09", "$%")
     // Generate pattern from these ranges
     val pattern = "[" + ranges.map(r => s"${r.head}-${r.last}").mkString + "]"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[CharacterClass]
 
     ranges zip parsedTree.children foreach { case (range, child) =>
       assert(clue(child) match {
@@ -204,7 +205,7 @@ trait ParserTest {
 
   test("Parse character class with predefined character classes") {
     val pattern = s"[$charClassPredefCharClasses]"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[CharacterClass]
 
     pattern.init.tail.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -218,7 +219,7 @@ trait ParserTest {
 
   test("Parse character class with quotes") {
     val pattern = """[\]]"""
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail
 
     assert(clue(parsedTree) match {
       case CharacterClass(nodes, _, true) => nodes.head.isInstanceOf[QuoteChar]
@@ -230,7 +231,7 @@ trait ParserTest {
 
   test("Parse character class with metacharacters") {
     val pattern = """[\\\t\n\r\f]"""
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[CharacterClass]
 
     // A backslash is added back in to represent the backslash in the pattern
     """\""" + pattern.tail.init.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
@@ -245,7 +246,7 @@ trait ParserTest {
 
   test("Parse character class with special characters") {
     val pattern = s"[$charClassSpecialChars]"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[CharacterClass]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[CharacterClass]
 
     pattern.tail.init zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -259,7 +260,7 @@ trait ParserTest {
 
   test("Parse escape characters") {
     val pattern = escapeCharacters
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     // A backslash is added back in to represent the backslash in the pattern
     """\""" + pattern.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
@@ -275,7 +276,7 @@ trait ParserTest {
   test("Parse control characters") {
     val controlChars: Seq[Char] = ('a' to 'z') ++ ('A' to 'Z')
     val pattern = (controlChars map ("""\c""" + _)).mkString
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     controlChars zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -289,7 +290,7 @@ trait ParserTest {
 
   test("Parse hexadecimal characters") {
     val pattern = hexCharacters
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     pattern.split("""\\""").tail zip parsedTree.children foreach { case (str, child) =>
       assert(clue(child) match {
@@ -303,7 +304,7 @@ trait ParserTest {
 
   test("Parse octal characters") {
     val pattern = octCharacters
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     pattern.split("""\\""").tail zip parsedTree.children foreach { case (str, child) =>
       assert(clue(child) match {
@@ -317,7 +318,7 @@ trait ParserTest {
 
   test("Parse predefined character class") {
     val pattern = predefCharClasses
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     pattern.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
@@ -332,7 +333,7 @@ trait ParserTest {
 
   test("Parse short greedy quantifiers") {
     val pattern = "a*b+c?"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
     assert(clue(parsedTree.children(1)).isInstanceOf[OneOrMore])
@@ -352,7 +353,7 @@ trait ParserTest {
 
   test("Parse short reluctant quantifiers") {
     val pattern = "a*?b+?c??"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
     assert(clue(parsedTree.children(1)).isInstanceOf[OneOrMore])
@@ -372,7 +373,7 @@ trait ParserTest {
 
   test("Parse short possessive quantifiers") {
     val pattern = "a*+b++c?+"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(clue(parsedTree.children(0)).isInstanceOf[ZeroOrMore])
     assert(clue(parsedTree.children(1)).isInstanceOf[OneOrMore])
@@ -392,7 +393,7 @@ trait ParserTest {
 
   test("Parse long greedy quantifiers") {
     val pattern = "a{1}b{1,}c{1,2}"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(parsedTree.children(0) match {
       case Quantifier(Character('a', _), 1, 1, _, GreedyQuantifier, true) => true
@@ -414,7 +415,7 @@ trait ParserTest {
 
   test("Parse long reluctant quantifiers") {
     val pattern = "a{1}?b{1,}?c{1,2}?"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(parsedTree.children(0) match {
       case Quantifier(Character('a', _), 1, 1, _, ReluctantQuantifier, true) => true
@@ -436,7 +437,7 @@ trait ParserTest {
 
   test("Parse long possessive quantifiers") {
     val pattern = "a{1}+b{1,}+c{1,2}+"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(parsedTree.children(0) match {
       case Quantifier(Character('a', _), 1, 1, _, PossessiveQuantifier, true) => true
@@ -463,7 +464,7 @@ trait ParserTest {
 
   test("Parse capturing group") {
     val pattern = "(hello)(world)"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     parsedTree.children foreach (child =>
       assert(
@@ -480,7 +481,7 @@ trait ParserTest {
 
   test("Parse nested capturing group") {
     val pattern = "(hello(world))"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail
 
     assert(clue(parsedTree) match {
       case Group(Concat(nodes, _), true, _) =>
@@ -497,7 +498,7 @@ trait ParserTest {
 
   test("Parse named capturing group") {
     val pattern = "(?<groupName1>hello)(?<GroupName2>world)"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(clue(parsedTree.children.head) match {
       case NamedGroup(_: Concat, name, _) => name == "groupName1"
@@ -513,7 +514,7 @@ trait ParserTest {
 
   test("Parse nested named capturing group") {
     val pattern = "(?<groupName1>hello(?<GroupName2>world))"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail
 
     assert(clue(parsedTree) match {
       case NamedGroup(Concat(nodes, _), "groupName1", _) =>
@@ -530,7 +531,7 @@ trait ParserTest {
 
   test("Parse non-capturing group") {
     val pattern = "(?:hello)(?:world)"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     parsedTree.children foreach (child =>
       assert(
@@ -547,7 +548,7 @@ trait ParserTest {
 
   test("Parse nested non-capturing group") {
     val pattern = "(?:hello(?:world))"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail
 
     assert(clue(parsedTree) match {
       case Group(Concat(nodes, _), false, _) =>
@@ -564,7 +565,7 @@ trait ParserTest {
 
   test("Parse positive lookahead") {
     val pattern = "(?=hello)"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, true, true, _) => true
@@ -576,7 +577,7 @@ trait ParserTest {
 
   test("Parse negative lookahead") {
     val pattern = "(?!hello)"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, false, true, _) => true
@@ -588,7 +589,7 @@ trait ParserTest {
 
   test("Parse positive lookbehind") {
     val pattern = "(?<=hello)"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity)
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail
 
     assert(clue(parsedTree) match {
       case Lookaround(_: Concat, true, false, _) => true
@@ -600,7 +601,7 @@ trait ParserTest {
 
   test("Parse negative lookbehind") {
     val pattern = "(?<!hello)"
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Lookaround]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Lookaround]
 
     assert(parsedTree.expr.isInstanceOf[Concat])
     assert(!clue(parsedTree).isPositive)
@@ -611,7 +612,7 @@ trait ParserTest {
 
   test("Parse named reference") {
     val pattern = """\k<name1>"""
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[NameReference]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[NameReference]
 
     assertEquals(parsedTree.name, "name1")
 
@@ -620,7 +621,7 @@ trait ParserTest {
 
   test("Parse character quote") {
     val pattern = """stuff\$hit"""
-    val parsedTree = Parser(pattern, parserFlavor).fold(fail(_), identity).to[Concat]
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
 
     assert(clue(parsedTree.children(5)) match {
       case QuoteChar('$', _) => true

--- a/design/diagram/ClassDiagram.puml
+++ b/design/diagram/ClassDiagram.puml
@@ -71,7 +71,7 @@ package "weaponregex" {
 WeaponRegeX -- ParserObject :> use
 WeaponRegeX -- TreeMutator :> use
 class WeaponRegeX {
-    + mutate(pattern : String, mutators : Seq[TokenMutator] = BuiltinMutators.all, mutationLevels : Seq[Int] = null ) : Try[Seq[Mutant]]
+    + mutate(pattern : String, mutators : Seq[TokenMutator] = BuiltinMutators.all, mutationLevels : Seq[Int] = null ) : Either[String, Seq[Mutant]]
 }
 
 WeaponRegeXJS -l- WeaponRegeX :> wrap
@@ -178,14 +178,14 @@ abstract class Parser {
     + pattern : String
     __
     .. production rule methods ..
-    + parse() : Try[RegexTree]
+    + parse() : Either[String, RegexTree]
 }
 
 ParserObject <..> Parser : companion
 ParserObject -- ParserJVM :> create
 ParserObject -- ParserJS :> create
 class ParserObject {
-    + apply(pattern : String, flavor: ParserFlavor) : Try[RegexTree]
+    + apply(pattern : String, flags: Option[String], flavor: ParserFlavor) : Either[String, RegexTree]
 }
 
 ' ===================== TreeMutator =====================

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,18 +6,18 @@
 
 <img src="images/WeaponRegeX_logo.svg" width="50%" alt="Weapon regeX Logo">
 
-Weapon regeX mutates regular expressions for use in mutation testing. It has been designed from the ground up 
+Weapon regeX mutates regular expressions for use in mutation testing. It has been designed from the ground up
 to support [Stryker Mutator](https://github.com/stryker-mutator). Weapon regeX is available for both
-JavaScript and Scala and is used in [Stryker4s](https://github.com/stryker-mutator/stryker4s) and 
-[StrykerJS](https://github.com/stryker-mutator/stryker-js) flavors of Stryker. 
+JavaScript and Scala and is used in [Stryker4s](https://github.com/stryker-mutator/stryker4s) and
+[StrykerJS](https://github.com/stryker-mutator/stryker-js) flavors of Stryker.
 The JavaScript version of the library is generated from Scala using [Scala.js](https://www.scala-js.org/).
 The generated mutant regular expressions cover human errors, such as edge cases and typos. A list of provided mutators is given below.
 For an introduction to mutation testing, see [Stryker's website](https://stryker-mutator.io/).
 
-
 The current supported versions for Scala are: `2.12` and `2.13`.
 
 # Getting started
+
 In case you want to incorporate Weapon-regeX into your project.
 
 ## Scala
@@ -32,11 +32,10 @@ Mutate!
 
 ```scala mdoc
 import weaponregex.WeaponRegeX
-import scala.util.{Try, Success, Failure}
 
 WeaponRegeX.mutate("^abc(d+|[xyz])$") match {
-  case Success(mutants) => mutants map (_.pattern)
-  case Failure(e)       => throw e
+  case Right(mutants) => mutants map (_.pattern)
+  case Left(e)       => throw new RuntimeException(e)
 }
 ```
 
@@ -80,7 +79,7 @@ def mutate(
   mutators: Seq[TokenMutator] = BuiltinMutators.all,
   mutationLevels: Seq[Int] = null,
   flavor: ParserFlavor = ParserFlavorJVM
-): Try[Seq[Mutant]] = ???
+): Either[String, Seq[Mutant]] = ???
 
 WeaponRegeX.mutate _
 ```
@@ -92,10 +91,10 @@ depending on the `mutationLevels` argument.
 A list of `mutationLevels` can also be passed to the function. The mutators will be filtered
 based on the levels in the list. If omitted, no filtering takes place.
 
-The `flavor` argument allows setting the parser flavor that will be used to parse the pattern. 
+The `flavor` argument allows setting the parser flavor that will be used to parse the pattern.
 Currently, we support a `ParserFlavorJVM` and `ParserFlavorJS`. By default in Scala the JVM flavor is used.
 
-This function will return a `Success` with `Seq[Mutant]` if it can be parsed, or a `Failure` otherwise.
+This function will return a `Right` with `Seq[Mutant]` if it can be parsed, or a `Left` with the error message otherwise.
 
 ## JavaScript
 
@@ -104,10 +103,10 @@ The `mutate` function can be called with regular expression flags and an options
 ```js
 import wrx from 'weapon-regex';
 
-let mutants = wrx.mutate('^abc(d+|[xyz])$', "u", {
+let mutants = wrx.mutate('^abc(d+|[xyz])$', 'u', {
   mutators: Array.from(wrx.mutators.values()),
   mutationLevels: [1, 2, 3],
-  flavor: ParserFlavorJS
+  flavor: ParserFlavorJS,
 });
 ```
 
@@ -121,30 +120,30 @@ This function will return a JavaScript Array of `Mutant` if it can be parsed, or
 
 All the supported mutators and at which mutation level they appear are shown in the table below.
 
-| Name                                                            |  1  |  2  |  3  |
+| Name                                                            | 1   | 2   | 3   |
 | --------------------------------------------------------------- | --- | --- | --- |
-| [BOLRemoval](#bolremoval)                                       |  ✅  |  ✅  |  ✅  |
-| [EOLRemoval](#eolremoval)                                       |  ✅  |  ✅  |  ✅  |
-| [BOL2BOI](#bol2boi)                                             |     |  ✅  |  ✅  |
-| [EOL2EOI](#eol2eoi)                                             |     |  ✅  |  ✅  |
-| [CharClassNegation](#charclassnegation)                         |  ✅  |
-| [CharClassChildRemoval](#charclasschildremoval)                 |     |  ✅  |  ✅  |
-| [CharClassAnyChar](#charclassanychar)                           |     |  ✅  |  ✅  |
-| [CharClassRangeModification](#charclassrangemodification)       |     |     |  ✅  |
-| [PredefCharClassNegation](#predefcharclassnegation)             |  ✅  |
-| [PredefCharClassNullification](#predefcharclassnullification)   |     |  ✅  |  ✅  |
-| [PredefCharClassAnyChar](#predefcharclassanychar)               |     |  ✅  |  ✅  |
-| [POSIXCharClassNegation](#posixcharclassnegation)               |  ✅  |
-| [QuantifierRemoval](#quantifierremoval)                         |  ✅  |
-| [QuantifierNChange](#quantifiernchange)                         |     |  ✅  |  ✅  |
-| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     |  ✅  |  ✅  |
-| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     |  ✅  |  ✅  |
-| [QuantifierNMModification](#quantifiernmmodification)           |     |  ✅  |  ✅  |
-| [QuantifierShortModification](#quantifiershortmodification)     |     |  ✅  |  ✅  |
-| [QuantifierShortChange](#quantifiershortchange)                 |     |  ✅  |  ✅  |
-| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     |  ✅  |
-| [GroupToNCGroup](#grouptoncgroup)                               |     |  ✅  |  ✅  |
-| [LookaroundNegation](#lookaroundnegation)                       |  ✅  |  ✅  |  ✅  |
+| [BOLRemoval](#bolremoval)                                       | ✅  | ✅  | ✅  |
+| [EOLRemoval](#eolremoval)                                       | ✅  | ✅  | ✅  |
+| [BOL2BOI](#bol2boi)                                             |     | ✅  | ✅  |
+| [EOL2EOI](#eol2eoi)                                             |     | ✅  | ✅  |
+| [CharClassNegation](#charclassnegation)                         | ✅  |
+| [CharClassChildRemoval](#charclasschildremoval)                 |     | ✅  | ✅  |
+| [CharClassAnyChar](#charclassanychar)                           |     | ✅  | ✅  |
+| [CharClassRangeModification](#charclassrangemodification)       |     |     | ✅  |
+| [PredefCharClassNegation](#predefcharclassnegation)             | ✅  |
+| [PredefCharClassNullification](#predefcharclassnullification)   |     | ✅  | ✅  |
+| [PredefCharClassAnyChar](#predefcharclassanychar)               |     | ✅  | ✅  |
+| [POSIXCharClassNegation](#posixcharclassnegation)               | ✅  |
+| [QuantifierRemoval](#quantifierremoval)                         | ✅  |
+| [QuantifierNChange](#quantifiernchange)                         |     | ✅  | ✅  |
+| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     | ✅  | ✅  |
+| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     | ✅  | ✅  |
+| [QuantifierNMModification](#quantifiernmmodification)           |     | ✅  | ✅  |
+| [QuantifierShortModification](#quantifiershortmodification)     |     | ✅  | ✅  |
+| [QuantifierShortChange](#quantifiershortchange)                 |     | ✅  | ✅  |
+| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     | ✅  |
+| [GroupToNCGroup](#grouptoncgroup)                               |     | ✅  | ✅  |
+| [LookaroundNegation](#lookaroundnegation)                       | ✅  | ✅  | ✅  |
 
 ## Boundary Mutators
 
@@ -425,13 +424,12 @@ Change a normal group to a non-capturing group.
 
 Flips the sign of a lookaround (lookahead, lookbehind) construct.
 
-| Original    | Mutated    |
-| ----------- | ---------- |
-| `(?=abc)`   | `(?!abc)`  |
-| `(?!abc)`   | `(?=abc)`  |
-| `(?<=abc)`  | `(?<!abc)` |
-| `(?<!abc)`  | `(?<=abc)` |
-
+| Original   | Mutated    |
+| ---------- | ---------- |
+| `(?=abc)`  | `(?!abc)`  |
+| `(?!abc)`  | `(?=abc)`  |
+| `(?<=abc)` | `(?<!abc)` |
+| `(?<!abc)` | `(?<=abc)` |
 
 [Back to table 🔝](#supported-mutators)
 


### PR DESCRIPTION
Returning an `Either` is considered cleaner than returning a `Try` because it is more explicit. Where a `Try` can mean '_any_ exception' (even `OutOfMemoryException` or unrelated things like `ConnectException`), an `Either` has a more strict domain of failures. Additionally, a `String` failure result makes it easier to handle and return to the user.

Since we'll have a major version release this seems like a good time to make a breaking change like this :)