### PR TITLE
Explicitly upcast intermediate result to aid program elaboration

### DIFF
--- a/core/src/main/scala/weaponregex/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/parser/ParserJVM.scala
@@ -89,7 +89,11 @@ class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
     *   `"[abc]"`
     */
   override def charClass[A: P]: P[CharacterClass] =
-    Indexed("[" ~ "^".!.? ~ (charClassIntersection.rep(exactly = 1) | classItem.rep(minCharClassItem)) ~ "]")
+    Indexed(
+      "[" ~ "^".!.? ~ ((charClassIntersection.rep(exactly = 1): P[Seq[RegexTree]]) | classItem.rep(
+        minCharClassItem
+      )) ~ "]"
+    )
       .map { case (loc, (hat, nodes)) => CharacterClass(nodes, loc, isPositive = hat.isEmpty) }
 
   /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`,


### PR DESCRIPTION
See lampepfl/dotty#18130 for context.

We add an explicit type ascription to help the compiler infer contextual arguments. This make the code future-proof against the next versions of the compiler. I have successfully compiled the project locally with Scala 3.3.2-RC1-bin-20230703-0a21ecf-NIGHTLY.