### PR TITLE
feat: add replacement field to Mutant

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import org.scalajs.linker.interface.{ESFeatures, ESVersion}
 import org.typelevel.scalacoptions.{ScalaVersion, ScalacOption, ScalacOptions}
 import org.typelevel.sbt.tpolecat.DevMode
-import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
+import com.typesafe.tools.mima.core.{MissingMethodProblem, MissingTypesProblem, Problem, ProblemFilters}
 
 // Skip publish root
 publish / skip := true
@@ -62,7 +62,10 @@ lazy val WeaponRegeX = projectMatrix
       .map(previousVersion => organization.value %% name.value % previousVersion)
       .toSet,
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[Problem]("weaponregex.internal.*")
+      ProblemFilters.exclude[Problem]("weaponregex.internal.*"),
+      // Adding fields to Mutant is not considered a breaking change
+      ProblemFilters.exclude[MissingMethodProblem]("weaponregex.model.mutation.Mutant.*"),
+      ProblemFilters.exclude[MissingTypesProblem]("weaponregex.model.mutation.Mutant$")
     )
   )
   .jvmPlatform(

--- a/core/src/main/scala/weaponregex/internal/TokenMutatorSyntax.scala
+++ b/core/src/main/scala/weaponregex/internal/TokenMutatorSyntax.scala
@@ -31,10 +31,15 @@ private[internal] trait TokenMutatorSyntax {
       * @return
       *   A [[weaponregex.model.mutation.Mutant]]
       */
-    def toMutantOf(token: RegexTree, location: Option[Location] = None, description: Option[String] = None): Mutant = {
+    def toMutantOf(
+        token: RegexTree,
+        replacement: String = pattern,
+        location: Option[Location] = None,
+        description: Option[String] = None
+    ): Mutant = {
       val loc: Location = location.getOrElse(token.location)
       val desc: String = description.getOrElse(self.description(token.build, pattern, loc))
-      Mutant(pattern, name, loc, levels, desc)
+      Mutant(pattern, name, loc, levels, desc, replacement)
     }
 
     /** Convert a mutated pattern string into a [[weaponregex.model.mutation.Mutant]] with the
@@ -49,12 +54,17 @@ private[internal] trait TokenMutatorSyntax {
       * @return
       *   A [[weaponregex.model.mutation.Mutant]]
       */
-    def toMutantBeforeChildrenOf(token: RegexTree, description: Option[String] = None): Mutant = {
-      val loc: Location = token match {
-        case node: Node if node.children.nonEmpty => Location(token.location.start, node.children.head.location.start)
-        case _                                    => token.location
+    def toMutantBeforeChildrenOf(
+        token: RegexTree,
+        replacement: String,
+        description: Option[String] = None
+    ): Mutant = {
+      val (loc: Location, r: String) = token match {
+        case node: Node if node.children.nonEmpty =>
+          (Location(token.location.start, node.children.head.location.start), replacement)
+        case _ => (token.location, pattern)
       }
-      toMutantOf(token, Some(loc), description)
+      toMutantOf(token, r, Some(loc), description)
     }
 
     /** Convert a mutated pattern string into a [[weaponregex.model.mutation.Mutant]] with the
@@ -69,12 +79,17 @@ private[internal] trait TokenMutatorSyntax {
       * @return
       *   A [[weaponregex.model.mutation.Mutant]]
       */
-    def toMutantAfterChildrenOf(token: RegexTree, description: Option[String] = None): Mutant = {
-      val loc: Location = token match {
-        case node: Node if node.children.nonEmpty => Location(node.children.last.location.end, token.location.end)
-        case _                                    => token.location
+    def toMutantAfterChildrenOf(
+        token: RegexTree,
+        replacement: String,
+        description: Option[String] = None
+    ): Mutant = {
+      val (loc: Location, r: String) = token match {
+        case node: Node if node.children.nonEmpty =>
+          (Location(node.children.last.location.end, token.location.end), replacement)
+        case _ => (token.location, pattern)
       }
-      toMutantOf(token, Some(loc), description)
+      toMutantOf(token, r, Some(loc), description)
     }
   }
 }

--- a/core/src/main/scala/weaponregex/internal/mutator/boundaryMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/boundaryMutator.scala
@@ -21,7 +21,7 @@ object BOLRemoval extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = token match {
     case node: Node =>
       node.children flatMap {
-        case child: BOL => Seq(token.buildWhile(_ ne child).toMutantOf(child))
+        case child: BOL => Seq(token.buildWhile(_ ne child).toMutantOf(child, replacement = ""))
         case _          => Nil
       }
     case _ => Nil
@@ -43,7 +43,7 @@ object EOLRemoval extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = token match {
     case node: Node =>
       node.children flatMap {
-        case child: EOL => Seq(token.buildWhile(_ ne child).toMutantOf(child))
+        case child: EOL => Seq(token.buildWhile(_ ne child).toMutantOf(child, replacement = ""))
         case _          => Nil
       }
     case _ => Nil

--- a/core/src/main/scala/weaponregex/internal/mutator/capturingMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/capturingMutator.scala
@@ -21,7 +21,7 @@ object GroupToNCGroup extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case group @ Group(_, true, _) => Seq(group.copy(isCapturing = false))
     case _                         => Nil
-  }) map (_.build.toMutantBeforeChildrenOf(token))
+  }) map (g => g.build.toMutantBeforeChildrenOf(token, replacement = g.prefix))
 }
 
 /** Mutator for lookaround constructs (lookahead, lookbehind) negation
@@ -39,5 +39,5 @@ object LookaroundNegation extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case la: Lookaround => Seq(la.copy(isPositive = !la.isPositive))
     case _              => Nil
-  }) map (_.build.toMutantBeforeChildrenOf(token))
+  }) map (g => g.build.toMutantBeforeChildrenOf(token, replacement = g.prefix))
 }

--- a/core/src/main/scala/weaponregex/internal/mutator/charClassMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/charClassMutator.scala
@@ -21,7 +21,7 @@ object CharClassNegation extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case cc: CharacterClass => Seq(cc.copy(isPositive = !cc.isPositive))
     case _                  => Nil
-  }) map (_.build.toMutantBeforeChildrenOf(token))
+  }) map (g => g.build.toMutantBeforeChildrenOf(token, replacement = g.prefix))
 }
 
 /** Mutator for character class child removal
@@ -40,6 +40,7 @@ object CharClassChildRemoval extends TokenMutator {
         .buildWhile(_ ne child)
         .toMutantOf(
           child,
+          replacement = "",
           description = Some(
             s"${child.location.show} Remove the child `${child.build}` from the character class `${token.build}`"
           )

--- a/core/src/main/scala/weaponregex/internal/mutator/predefCharClassMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/predefCharClassMutator.scala
@@ -77,5 +77,5 @@ object UnicodeCharClassNegation extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case ucc: UnicodeCharClass => Seq(ucc.copy(isPositive = !ucc.isPositive))
     case _                     => Nil
-  }) map (_.build.toMutantBeforeChildrenOf(token))
+  }) map (g => g.build.toMutantBeforeChildrenOf(token, replacement = g.prefix))
 }

--- a/core/src/main/scala/weaponregex/internal/mutator/quantifierMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/quantifierMutator.scala
@@ -24,7 +24,7 @@ object QuantifierRemoval extends TokenMutator {
     case q: OneOrMore  => Seq(q.expr)
     case q: Quantifier => Seq(q.expr)
     case _             => Nil
-  }) map (_.build.toMutantAfterChildrenOf(token))
+  }) map (m => m.build.toMutantAfterChildrenOf(token, replacement = ""))
 }
 
 /** Mutator for quantifier `{n}` to `{0,n}` and `{n,}` change
@@ -46,7 +46,7 @@ object QuantifierNChange extends TokenMutator {
         q.copy(isExact = false, max = Quantifier.Infinity)
       )
     case _ => Nil
-  }) map (_.build.toMutantAfterChildrenOf(token))
+  }) map (m => m.build.toMutantAfterChildrenOf(token, replacement = m.postfix))
 }
 
 /** Mutator for quantifier `{n,}` to `{n-1,}` and `{n+1,}` modification
@@ -66,7 +66,7 @@ object QuantifierNOrMoreModification extends TokenMutator {
       if (q.min < 1) Seq(q.copy(min = q.min + 1))
       else Seq(q.copy(min = q.min - 1), q.copy(min = q.min + 1))
     case _ => Nil
-  }) map (_.build.toMutantAfterChildrenOf(token))
+  }) map (m => m.build.toMutantAfterChildrenOf(token, replacement = m.postfix))
 }
 
 /** Mutator for quantifier `{n,}` to `{n}` change
@@ -84,7 +84,7 @@ object QuantifierNOrMoreChange extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case q: Quantifier if !q.isExact && q.max == Quantifier.Infinity => Seq(q.copy(isExact = true))
     case _                                                           => Nil
-  }) map (_.build.toMutantAfterChildrenOf(token))
+  }) map (m => m.build.toMutantAfterChildrenOf(token, replacement = m.postfix))
 }
 
 /** Mutator for quantifier `{n,m}` modification (including `{n-1,m}`, `{n+1,m}`, `{n,m-1}`, and `{n,m+1}`)
@@ -119,7 +119,7 @@ object QuantifierNMModification extends TokenMutator {
           )
       }
     case _ => Nil
-  }) map (_.build.toMutantAfterChildrenOf(token))
+  }) map (m => m.build.toMutantAfterChildrenOf(token, replacement = m.postfix))
 }
 
 /** Mutator for short quantifier to `{n,}` or `{n,m}` modification
@@ -149,7 +149,7 @@ object QuantifierShortModification extends TokenMutator {
         Quantifier(q.expr, min = 2, max = Quantifier.Infinity, q.location, q.quantifierType)
       )
     case _ => Nil
-  }) map (_.build.toMutantAfterChildrenOf(token))
+  }) map (m => m.build.toMutantAfterChildrenOf(token, replacement = m.postfix))
 }
 
 /** Mutator for short quantifier `*` and `+` to `{n}` change
@@ -170,7 +170,7 @@ object QuantifierShortChange extends TokenMutator {
     case q: OneOrMore =>
       Seq(Quantifier(q.expr, exact = 1, q.location, q.quantifierType))
     case _ => Nil
-  }) map (_.build.toMutantAfterChildrenOf(token))
+  }) map (m => m.build.toMutantAfterChildrenOf(token, replacement = m.postfix))
 }
 
 /** Mutator for greedy quantifier to reluctant quantifier modification
@@ -195,5 +195,5 @@ object QuantifierReluctantAddition extends TokenMutator {
     case q: Quantifier if q.quantifierType == GreedyQuantifier =>
       Seq(q.copy(quantifierType = ReluctantQuantifier))
     case _ => Nil
-  }) map (_.build.toMutantAfterChildrenOf(token))
+  }) map (m => m.build.toMutantAfterChildrenOf(token, replacement = m.postfix))
 }

--- a/core/src/main/scala/weaponregex/model/mutation/Mutant.scala
+++ b/core/src/main/scala/weaponregex/model/mutation/Mutant.scala
@@ -13,5 +13,14 @@ import weaponregex.model.Location
   *   The mutation levels of the mutator
   * @param description
   *   Description on the mutation
+  * @param replacement
+  *   The part of the pattern that has been changed
   */
-case class Mutant(pattern: String, name: String, location: Location, levels: Seq[Int], description: String)
+case class Mutant(
+    pattern: String,
+    name: String,
+    location: Location,
+    levels: Seq[Int],
+    description: String,
+    replacement: String
+)

--- a/core/src/main/scalajs/weaponregex/model/mutation/MutantJS.scala
+++ b/core/src/main/scalajs/weaponregex/model/mutation/MutantJS.scala
@@ -34,4 +34,8 @@ case class MutantJS(mutant: Mutant) {
   /** Description on the mutation
     */
   val description: String = mutant.description
+
+  /** The part of the pattern that has been changed
+    */
+  val replacement: String = mutant.replacement
 }

--- a/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
@@ -22,9 +22,10 @@ trait ParserTest {
   val octCharacters: String
   val predefCharClasses: String
 
-  def treeBuildTest(tree: RegexTree, pattern: String): Unit = assertEquals(tree.build, pattern)
+  def treeBuildTest(tree: RegexTree, pattern: String)(implicit loc: Location): Unit =
+    assertEquals(tree.build, pattern)
 
-  def parseErrorTest(pattern: String, flags: Option[String] = None): Unit = {
+  def parseErrorTest(pattern: String, flags: Option[String] = None)(implicit loc: Location): Unit = {
     val parsedTree = Parser(pattern, flags, parserFlavor)
 
     assert(clue(parsedTree) match {
@@ -640,6 +641,11 @@ trait ParserTest {
   test("Parser failure mid-regex") {
     val pattern = "abc(def"
     parseErrorTest(pattern)
+  }
+
+  test("Parse complex regular expression") {
+    val pattern = """^(a*|b+(?=c)|[[c-z]XYZ]{3,}(ABC{4}DEF{5,9}\w)\p{Alpha})$"""
+    treeBuildTest(Parser(pattern, parserFlavor).getOrFail, pattern)
   }
 
   implicit class RegexTreeCastExtension(tree: RegexTree) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,22 @@
 export interface Location {
-    start: Position;
-    end: Position;
+  start: Position;
+  end: Position;
+
+  get show(): string;
 }
 
 export interface Position {
-    line: number;
-    column: number;
+  line: number;
+  column: number;
 }
 
 // Classes with markers so the union type works properly
 declare class ParserFlavorJSClass {
-    private __marker: 'js';
+  private __marker: 'js';
 }
 
 declare class ParserFlavorJVMClass {
-    private __marker: 'jvm';
+  private __marker: 'jvm';
 }
 
 export const ParserFlavorJS: ParserFlavorJSClass;
@@ -23,36 +25,40 @@ export const ParserFlavorJVM: ParserFlavorJVMClass;
 export type ParserFlavor = typeof ParserFlavorJS | typeof ParserFlavorJVM;
 
 export interface TokenMutator {
-    name: string;
-    levels: number[];
+  name: string;
+  levels: number[];
 }
 
 export interface MutationOptions {
-    mutators?: TokenMutator[];
-    mutationLevels?: number[];
-    flavor?: ParserFlavor;
+  mutators?: TokenMutator[];
+  mutationLevels?: number[];
+  flavor?: ParserFlavor;
 }
 
 export interface Mutant {
-    /** The replacement pattern
-     */
-    pattern: string;
+  /** The replacement pattern
+   */
+  pattern: string;
 
-    /** Name of the mutation
-     */
-    name: string;
+  /** Name of the mutation
+   */
+  name: string;
 
-    /** [[weaponregex.model.Location]] in the original string where the mutation occurred
-     */
-    location: Location;
+  /** [[weaponregex.model.Location]] in the original string where the mutation occurred
+   */
+  location: Location;
 
-    /** The mutation levels of the mutator
-     */
-    levels: number[];
+  /** The mutation levels of the mutator
+   */
+  levels: number[];
 
-    /** Description on the mutation
-     */
-    description: string;
+  /** Description on the mutation
+   */
+  description: string;
+
+  /** The part of the pattern that has been changed
+   */
+  replacement: string;
 }
 
 /** Mutate a regex pattern and flags with the given options.
@@ -73,38 +79,42 @@ export interface Mutant {
  * @return
  *   A JavaScript Array of [[weaponregex.model.mutation.Mutant]] if can be parsed, or throw an exception otherwise
  */
-export function mutate(pattern: string, flags?: string, options?: MutationOptions): Mutant[];
+export function mutate(
+  pattern: string,
+  flags?: string | null,
+  options?: MutationOptions | null
+): Mutant[];
 
 /** JS Map that maps from a token mutator class names to the associating token mutator
  */
 export const mutators: Map<string, TokenMutator>;
 
 export const BuiltinMutators: {
-    /** JS Array of all built-in token mutators
-     */
-    all: TokenMutator[];
+  /** JS Array of all built-in token mutators
+   */
+  all: TokenMutator[];
 
-    /** JS Map that maps from a token mutator class names to the associating token mutator
-     */
-    byName: Map<string, TokenMutator>;
+  /** JS Map that maps from a token mutator class names to the associating token mutator
+   */
+  byName: Map<string, TokenMutator>;
 
-    /** JS Map that maps from mutation level number to token mutators in that level
-     */
-    byLevel: Map<number, TokenMutator[]>;
+  /** JS Map that maps from mutation level number to token mutators in that level
+   */
+  byLevel: Map<number, TokenMutator[]>;
 
-    /** Get all the token mutators in the given mutation level
-     * @param mutationLevel
-     *   Mutation level number
-     * @return
-     *   Array of all the tokens mutators in that level, if any
-     */
-    atLevel(mutationLevel: number): TokenMutator[];
+  /** Get all the token mutators in the given mutation level
+   * @param mutationLevel
+   *   Mutation level number
+   * @return
+   *   Array of all the tokens mutators in that level, if any
+   */
+  atLevel(mutationLevel: number): TokenMutator[];
 
-    /** Get all the token mutators in the given mutation levels
-     * @param mutationLevels
-     *   Mutation level numbers
-     * @return
-     *   Array of all the tokens mutators in that levels, if any
-     */
-    atLevels(mutationLevels: number[]): TokenMutator[];
+  /** Get all the token mutators in the given mutation levels
+   * @param mutationLevels
+   *   Mutation level numbers
+   * @return
+   *   Array of all the tokens mutators in that levels, if any
+   */
+  atLevels(mutationLevels: number[]): TokenMutator[];
 };

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -12,7 +12,8 @@
         "mocha": "^10.2.0"
       },
       "devDependencies": {
-        "@types/mocha": "^10.0.6"
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^20.10.5"
       }
     },
     "node_modules/@types/mocha": {
@@ -20,6 +21,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -758,6 +768,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/workerpool": {
       "version": "6.2.1",

--- a/node/package.json
+++ b/node/package.json
@@ -14,6 +14,7 @@
     "mocha": "^10.2.0"
   },
   "devDependencies": {
-    "@types/mocha": "^10.0.6"
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^20.10.5"
   }
 }

--- a/node/test/api.js
+++ b/node/test/api.js
@@ -1,12 +1,16 @@
 /// <reference types="mocha" />
+/// <reference types="node" />
+// @ts-check
+import * as wrx from '../../core/target/js-3/weapon-regex-fastopt/main.js';
+import assert from 'assert';
 
-import {
+// @ts-ignore
+/** @type {import('../../')} */ const {
   mutate,
   mutators,
   ParserFlavorJS,
   ParserFlavorJVM,
-} from '../../core/target/js-3/weapon-regex-fastopt/main.js';
-import assert from 'assert';
+} = wrx;
 
 describe('Weapon regeX', () => {
   describe('#mutate()', () => {
@@ -77,7 +81,7 @@ describe('Weapon regeX', () => {
     it('Catch an exception if the RegEx is invalid', () => {
       assert.throws(
         () => mutate('*(a|$]'),
-        (e) => e.message.startsWith('[Error] Parser: ')
+        (/** @type {Error} */ e) => e.message.startsWith('[Error] Parser: ')
       );
     });
   });
@@ -123,8 +127,16 @@ describe('Weapon regeX', () => {
       assert.strictEqual(mutants.length, 1);
       assert.strictEqual(
         mutants[0].description,
-          mutants[0].location.show + ' Remove the beginning of line character `^`'
+        mutants[0].location.show + ' Remove the beginning of line character `^`'
       );
+    });
+
+    it('Contains the mutator replacement', () => {
+      const mutants = mutate('^a$', undefined, { mutationLevels: [1] });
+
+      assert.strictEqual(mutants.length, 2);
+      assert.strictEqual(mutants[0].replacement, '');
+      assert.strictEqual(mutants[1].replacement, '');
     });
   });
 


### PR DESCRIPTION
Adds a new field `replacement` to the Mutant class. This field contains the actually newly replaced part of the pattern, corresponding to the `location`.

Reason for adding this is because there is a mismatch between `pattern` and `location`. So for accurate location reporting, we need the part of the `location` that has been changed.

This allows the report to look like this:

![image](https://github.com/stryker-mutator/weapon-regex/assets/10114577/88d12193-c3e5-47d3-9c7f-0b70a4aa095a)
![image](https://github.com/stryker-mutator/weapon-regex/assets/10114577/cca1fd36-443a-4489-adc3-936e4fb1bb1c)

