### PR TITLE
fix(parser): support valid JS group names

### DIFF
--- a/core/src/main/scala/weaponregex/internal/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/Parser.scala
@@ -441,13 +441,13 @@ abstract private[weaponregex] class Parser(val pattern: String) {
   def group[A: P]: P[Group] = Indexed("(" ~ RE ~ ")")
     .map { case (loc, expr) => Group(expr, isCapturing = true, loc) }
 
-  /** Parse a group name that starts with a letter and followed by zero or more alphanumeric characters
+  /** Parse a group name
     * @return
     *   the parsed name string
     * @example
     *   `"name1"`
     */
-  def groupName[A: P]: P[String] = P(CharIn("a-z", "A-Z") ~ CharIn("a-z", "A-Z", "0-9").rep).!
+  def groupName[A: P]: P[String]
 
   /** Parse a named-capturing group
     * @return

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
@@ -73,6 +73,15 @@ private[weaponregex] class ParserJS private[parser] (pattern: String, val flags:
     else
       P(preDefinedCharClass | metaCharacter | range | quoteChar | charClassCharLiteral)
 
+  /** Parse a group name
+    * @return
+    *   the parsed name string
+    * @example
+    *   `"name1"`
+    */
+  override def groupName[A: P]: P[String] =
+    P(CharIn("a-z", "A-Z", "_") ~ CharIn("a-z", "A-Z", "0-9", "_").rep).!
+
   /** Parse a quoted character (any character). If [[weaponregex.internal.parser.ParserJS unicodeMode]] is true, only
     * the following characters are allowed: `^ $ \ . * + ? ( ) [ ] { } |` or `/`
     * @return

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJVM.scala
@@ -97,6 +97,15 @@ private[weaponregex] class ParserJVM private[parser] (pattern: String) extends P
     )
       .map { case (loc, (hat, nodes)) => CharacterClass(nodes, loc, isPositive = hat.isEmpty) }
 
+  /** Parse a group name
+    * @return
+    *   the parsed name string
+    * @example
+    *   `"name1"`
+    */
+  override def groupName[A: P]: P[String] =
+    P(CharIn("a-z", "A-Z") ~ CharIn("a-z", "A-Z", "0-9").rep).!
+
   /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`,
     * `flagToggleGroup`, `flagNCGroup`, `lookaround` or `atomicGroup`
     * @return


### PR DESCRIPTION
JVM and JS have different definitions of a valid group name.

In JVM, a group name is simply `[A-Za-z][A-Za-z0-9]` ([source](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#groupname)), which weapon-regex is currently using.

In JS, it is a bit more complicated. It only says that a group name must be a valid identifier ([source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group#name)), but it doesn’t say whether all identifiers are valid group name. 
> In JavaScript, identifiers are commonly made of alphanumeric characters, underscores (`_`), and dollar signs (`$`). Identifiers are not allowed to start with numbers. However, JavaScript identifiers are not only limited to ASCII — many Unicode code points are allowed as well.
> 
> ([source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers))

Some quick tests on [regex101](https://regex101.com/r/OAekVc) show that JS doesn't allow group names with `$` or Unicode characters.

This PR separates the group name rule to allow JS group names with underscores.