### PR TITLE
feat(parser): switch over to cats-parse

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/setup
       - name: Run stryker
-        run: sbt 'project WeaponRegeX; stryker --reporters console --reporters dashboard'
+        run: sbt 'WeaponRegeX/stryker --reporters console --reporters dashboard'
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -2,3 +2,4 @@ OrganizeImports {
   coalesceToWildcardImportThreshold = 5
   groupedImports = Merge
 }
+OrganizeImports.targetDialect = Scala3

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val WeaponRegeX = projectMatrix
   .in(file("core"))
   .settings(
     name := "weapon-regex",
-    libraryDependencies += "com.lihaoyi" %%% "fastparse" % "3.1.1",
+    libraryDependencies += "org.typelevel" %%% "cats-parse" % "1.1.0",
     libraryDependencies += "org.scalameta" %%% "munit" % "1.3.1" % Test,
     tpolecatScalacOptions ++= Set(
       ScalacOptions.source3,

--- a/core/src/main/scala/weaponregex/internal/extension/StringExtension.scala
+++ b/core/src/main/scala/weaponregex/internal/extension/StringExtension.scala
@@ -1,53 +1,6 @@
 package weaponregex.internal.extension
 
-import fastparse.internal.Util
-import weaponregex.model.*
-
 private[weaponregex] object StringExtension {
-  implicit class StringIndexExtension(val string: String) extends AnyVal {
-
-    /** Convert an index of into row and column numbers in the given string.
-      *
-      * @param index
-      *   An index
-      * @return
-      *   A tuple of row and column numbers
-      *
-      * @note
-      *   This function implementation is taken from
-      *   [[https://github.com/lihaoyi/fastparse/blob/master/fastparse/src/fastparse/ParserInput.scala here]]
-      */
-    final def toLineCol(index: Int): (Int, Int) = {
-      val lineNumberLookup = Util.lineNumberLookup(string)
-      val line = lineNumberLookup.indexWhere(_ > index) match {
-        case -1 => lineNumberLookup.length - 1
-        case n  => math.max(0, n - 1)
-      }
-      val col = index - lineNumberLookup(line)
-      (line, col)
-    }
-
-    /** Convert an index into a [[weaponregex.model.Position]] in the given string.
-      * @param index
-      *   An index
-      * @return
-      *   A [[weaponregex.model.Position]]
-      */
-    final def positionOf(index: Int): Position = {
-      val (line, column) = string.toLineCol(index)
-      Position(line, column)
-    }
-
-    /** Convert a pair of start and end indices into a [[weaponregex.model.Location]] in the given string.
-      * @param start
-      *   Start index
-      * @param end
-      *   End index
-      * @return
-      *   A [[weaponregex.model.Location]]
-      */
-    final def locationOf(start: Int, end: Int): Location = Location(string.positionOf(start), string.positionOf(end))
-  }
 
   implicit class StringStylingExtension(val string: String) extends AnyVal {
 
@@ -55,6 +8,15 @@ private[weaponregex] object StringExtension {
       * @return
       *   Case-toggled String
       */
-    final def toggleCase: String = string map (char => if (char.isUpper) char.toLower else char.toUpper)
+    final def toggleCase: String = string.map(_.toggleCase)
+  }
+
+  implicit class CharStylingExtension(val char: Char) extends AnyVal {
+
+    /** Toggle the case of a character
+      * @return
+      *   Case-toggled character
+      */
+    final def toggleCase: Char = if (char.isUpper) char.toLower else char.toUpper
   }
 }

--- a/core/src/main/scala/weaponregex/internal/model/regextree/boundaryNode.scala
+++ b/core/src/main/scala/weaponregex/internal/model/regextree/boundaryNode.scala
@@ -21,4 +21,4 @@ case class EOL(override val location: Location) extends Leaf('$', location)
   * @param location
   *   The [[weaponregex.model.Location]] of the node in the regex string
   */
-case class Boundary(boundary: String, override val location: Location) extends Leaf(boundary, location, """\""")
+case class Boundary(boundary: Char, override val location: Location) extends Leaf(boundary, location, """\""")

--- a/core/src/main/scala/weaponregex/internal/model/regextree/characterNode.scala
+++ b/core/src/main/scala/weaponregex/internal/model/regextree/characterNode.scala
@@ -37,8 +37,7 @@ case class MetaChar(metaChar: String, override val location: Location) extends L
   *   This is technically a meta-character, but because it has an additional target character and a `\c` prefix, it is
   *   handled separately here
   */
-case class ControlChar(controlChar: String, override val location: Location)
-    extends Leaf(controlChar, location, """\c""")
+case class ControlChar(controlChar: Char, override val location: Location) extends Leaf(controlChar, location, """\c""")
 
 /** Empty string (nothing, null) leaf
   * @param location

--- a/core/src/main/scala/weaponregex/internal/model/regextree/predefinedCharClassNode.scala
+++ b/core/src/main/scala/weaponregex/internal/model/regextree/predefinedCharClassNode.scala
@@ -9,7 +9,7 @@ import weaponregex.model.Location
   * @param location
   *   The [[weaponregex.model.Location]] of the node in the regex string
   */
-case class PredefinedCharClass(charClass: String, override val location: Location)
+case class PredefinedCharClass(charClass: Char, override val location: Location)
     extends Leaf(charClass, location, """\""")
 
 /** Unicode character class leaf node

--- a/core/src/main/scala/weaponregex/internal/mutator/boundaryMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/boundaryMutator.scala
@@ -63,7 +63,7 @@ object BOL2BOI extends TokenMutator {
     location.show + """ Change the beginning of line `^` to beginning of input `\A`"""
 
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
-    case _: BOL => Seq(Boundary("A", token.location))
+    case _: BOL => Seq(Boundary('A', token.location))
     case _      => Nil
   }) map (_.build.toMutantOf(token))
 }
@@ -81,7 +81,7 @@ object EOL2EOI extends TokenMutator {
     location.show + """ Change the end of line `$` to end of input `\z`"""
 
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
-    case _: EOL => Seq(Boundary("z", token.location))
+    case _: EOL => Seq(Boundary('z', token.location))
     case _      => Nil
   }) map (_.build.toMutantOf(token))
 }

--- a/core/src/main/scala/weaponregex/internal/mutator/charClassMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/charClassMutator.scala
@@ -70,7 +70,7 @@ object CharClassAnyChar extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case cc: CharacterClass =>
       Seq(
-        CharacterClass(Seq(PredefinedCharClass("w", cc.location), PredefinedCharClass("W", cc.location)), cc.location)
+        CharacterClass(Seq(PredefinedCharClass('w', cc.location), PredefinedCharClass('W', cc.location)), cc.location)
       )
     case _ => Nil
   }) map (_.build.toMutantOf(token))

--- a/core/src/main/scala/weaponregex/internal/mutator/predefCharClassMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/predefCharClassMutator.scala
@@ -2,7 +2,7 @@ package weaponregex.internal.mutator
 
 import weaponregex.internal.TokenMutator
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
-import weaponregex.internal.extension.StringExtension.StringStylingExtension
+import weaponregex.internal.extension.StringExtension.*
 import weaponregex.internal.model.regextree.*
 import weaponregex.model.Location
 import weaponregex.model.mutation.Mutant
@@ -40,7 +40,7 @@ object PredefCharClassNullification extends TokenMutator {
   override def mutate(token: RegexTree): Seq[Mutant] = (token match {
     case pdcc: PredefinedCharClass => Seq(pdcc.charClass)
     case _                         => Nil
-  }) map (_.toMutantOf(token))
+  }) map (_.toString.toMutantOf(token))
 }
 
 /** Mutator for predefined character class to character class with its negation change

--- a/core/src/main/scala/weaponregex/internal/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/Parser.scala
@@ -1,13 +1,12 @@
 package weaponregex.internal.parser
 
-import fastparse.*
+import cats.parse.Rfc5234.*
+import cats.parse.{Numbers, Parser as P, Parser0 as P0}
+import cats.syntax.show.*
 import weaponregex.internal.constant.ErrorMessage
-import weaponregex.internal.extension.StringExtension.StringIndexExtension
 import weaponregex.internal.model.regextree.*
 import weaponregex.model.*
 import weaponregex.parser.*
-
-import NoWhitespace.*
 
 /** Companion object for [[weaponregex.internal.parser.Parser]] class that instantiates flavor-specific parsers
   * instances
@@ -27,8 +26,8 @@ private[weaponregex] object Parser {
     flavor match {
       case ParserFlavorJVM =>
         if (flags.isDefined) Left(ErrorMessage.jvmWithStringFlags)
-        else new ParserJVM(pattern).parse
-      case ParserFlavorJS => new ParserJS(pattern, flags).parse
+        else ParserJVM.parse(pattern)
+      case ParserFlavorJS => ParserJS(flags).parse(pattern)
       case null           => Left(ErrorMessage.unsupportedFlavor)
     }
 
@@ -44,42 +43,40 @@ private[weaponregex] object Parser {
 }
 
 /** The based abstract parser
-  * @param pattern
-  *   The regex pattern to be parsed
   * @note
   *   The parsing rules methods inside this class is created based on the defined grammar
   */
-abstract private[weaponregex] class Parser(val pattern: String) {
+abstract private[weaponregex] class Parser {
 
   /** Regex special characters
     */
-  val specialChars: String
+  protected val specialChars: String
 
   /** Special characters within a character class
     */
-  val charClassSpecialChars: String
+  protected val charClassSpecialChars: String
 
   /** Allowed boundary meta-characters
     */
-  val boundaryMetaChars: String
+  protected val boundaryMetaChars: String
 
   /** Allowed escape characters
     */
-  val escapeChars: String
+  protected val escapeChars: String
 
   /** Allowed predefined character class characters
     */
-  val predefCharClassChars: String
+  protected val predefCharClassChars: String
 
   /** Minimum number of character class items of a valid character class
     */
-  val minCharClassItem: Int
+  protected val minCharClassItem: Int
 
   /** The escape character used with a code point
     * @example
     *   `\ x{h..h}` or `\ u{h..h}`
     */
-  val codePointEscChar: String
+  protected val codePointEscChar: Char
 
   /** A higher order parser that add [[weaponregex.model.Location]] index information of the parse of the given parser
     * @param p
@@ -87,8 +84,19 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @return
     *   A tuple of the [[weaponregex.model.Location]] of the parse, and the return of the given parser `p`
     */
-  def Indexed[A: P, T](p: => P[T]): P[(Location, T)] = P(Index ~ p ~ Index)
-    .map { case (i, t, j) => (pattern.locationOf(i, j), t) }
+  protected def indexed[A](p: P[A]): P[(Location, A)] =
+    (P.caret.with1 ~ p ~ P.caret).map { case ((i, a), j) => (Location.fromCaret(i, j), a) }
+
+  /** A higher order parser that add [[weaponregex.model.Location]] index information of the parse of the given parser
+    * @param p
+    *   the parser to be indexed
+    * @return
+    *   A tuple of the [[weaponregex.model.Location]] of the parse, and the return of the given parser `p`
+    */
+  protected def indexed0[A](p: P0[A]): P0[(Location, A)] =
+    (P.caret ~ p ~ P.caret).map { case ((i, a), j) => (Location.fromCaret(i, j), a) }
+
+  protected val backslash: P[Unit] = P.char('\\')
 
   /** Parse an integer with any number of digits between 0 and 9
     * @return
@@ -96,13 +104,13 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"123"`
     */
-  def number[A: P]: P[Int] = P(CharIn("0-9").rep(1).!) map (_.toInt)
+  protected val number: P[Int] = Numbers.nonNegativeIntString.map(_.toInt)
 
   /** Parse special cases of a character literal
     * @return
     *   The captured character as a string
     */
-  def charLiteralSpecialCases[A: P]: P[String] = Fail
+  protected val charLiteralSpecialCases: P[Char] = P.fail
 
   /** Parse a single literal character that is not a regex special character
     * @return
@@ -112,15 +120,16 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @see
     *   [[weaponregex.internal.parser.Parser.specialChars]]
     */
-  def charLiteral[A: P]: P[Character] =
-    Indexed(CharPred(!specialChars.contains(_)).! | charLiteralSpecialCases)
-      .map { case (loc, c) => Character(c.head, loc) }
+  protected val charLiteral: P[Character] =
+    indexed(
+      P.defer(P.charWhere(c => !specialChars.contains(c)) | charLiteralSpecialCases)
+    ).map { case (loc, c) => Character(c, loc) }
 
   /** Intermediate parsing rule for character-related tokens which can parse either `metaCharacter` or `charLiteral`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def character[A: P]: P[RegexTree] = P(metaCharacter | charLiteral)
+  protected val character: P[RegexTree] = P.defer(metaCharacter.backtrack) | charLiteral
 
   /** Parse a beginning of line character (`^`)
     * @return
@@ -128,8 +137,7 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"^"`
     */
-  def bol[A: P]: P[BOL] = Indexed(P("^"))
-    .map { case (loc, _) => BOL(loc) }
+  protected val bol: P[BOL] = indexed(P.char('^')).map { case (loc, _) => BOL(loc) }
 
   /** Parse a beginning of line character (`$`)
     * @return
@@ -137,8 +145,7 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"$"`
     */
-  def eol[A: P]: P[EOL] = Indexed(P("$"))
-    .map { case (loc, _) => EOL(loc) }
+  protected val eol: P[EOL] = indexed(P.char('$')).map { case (loc, _) => EOL(loc) }
 
   /** Parse a boundary meta-character character
     * @return
@@ -148,22 +155,31 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @see
     *   [[weaponregex.internal.parser.Parser.boundaryMetaChars]]
     */
-  def boundaryMetaChar[A: P]: P[Boundary] = Indexed("""\""" ~ CharPred(boundaryMetaChars.contains(_)).!)
-    .map { case (loc, b) => Boundary(b, loc) }
+  protected val boundaryMetaChar: P[Boundary] =
+    indexed(backslash *> P.defer(P.charIn(boundaryMetaChars)))
+      .map { case (loc, b) => Boundary(b, loc) }
 
   /** Intermediate parsing rule for boundary tokens which can parse either `bol`, `eol` or `boundaryMetaChar`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def boundary[A: P]: P[RegexTree] = P(bol | eol | boundaryMetaChar)
+  protected val boundary: P[RegexTree] = bol | eol | boundaryMetaChar.backtrack
 
   /** Intermediate parsing rule for meta-character tokens which can parse either `charOct`, `charHex`, `charUnicode`,
     * `charHexBrace` or `escapeChar`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def metaCharacter[A: P]: P[RegexTree] = P(
-    charOct | charHex | charUnicode | charCodePoint | hexEscCharConsumer | escapeChar | controlChar
+  protected val metaCharacter: P[RegexTree] = P.defer(
+    P.oneOf(
+      charOct.backtrack ::
+        charHex.backtrack ::
+        charUnicode.backtrack ::
+        charCodePoint.backtrack ::
+        hexEscCharConsumer ::
+        escapeChar.backtrack ::
+        controlChar.backtrack :: Nil
+    )
   )
 
   /** Parse an escape meta-character
@@ -174,9 +190,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @see
     *   [[weaponregex.internal.parser.Parser.escapeChars]]
     */
-  def escapeChar[A: P]: P[MetaChar] =
-    Indexed("""\""" ~ CharPred(escapeChars.contains(_)).!)
-      .map { case (loc, c) => MetaChar(c, loc) }
+  protected val escapeChar: P[MetaChar] =
+    indexed(backslash *> P.defer(P.charIn(escapeChars)))
+      .map { case (loc, c) => MetaChar(c.toString(), loc) }
 
   /** Parse an control meta-character based on caret notation
     * @return
@@ -186,8 +202,8 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @see
     *   [[https://en.wikipedia.org/wiki/Caret_notation]]
     */
-  def controlChar[A: P]: P[ControlChar] =
-    Indexed("""\c""" ~ CharIn("a-zA-Z").!)
+  protected val controlChar: P[ControlChar] =
+    indexed(P.string("\\c") *> alpha)
       .map { case (loc, c) => ControlChar(c, loc) }
 
   /** Parse a character with octal value
@@ -196,15 +212,7 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"\012"`
     */
-  def charOct[A: P]: P[MetaChar]
-
-  /** Parse a single hexadecimal digit
-    * @return
-    *   the parsed hexadecimal digit as a `String`
-    * @example
-    *   `"F"`
-    */
-  def hexDigit[A: P]: P[String] = P(CharIn("0-9a-fA-F").!)
+  protected val charOct: P[MetaChar]
 
   /** Parse a character with hexadecimal value `\xhh`
     * @return
@@ -212,8 +220,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"\x01"`
     */
-  def charHex[A: P]: P[MetaChar] = Indexed("""\x""" ~ hexDigit.rep(exactly = 2).!)
-    .map { case (loc, hexDigits) => MetaChar("x" + hexDigits, loc) }
+  protected val charHex: P[MetaChar] =
+    indexed(P.string("\\x") *> hexdig.repExactlyAs[String](2))
+      .map { case (loc, hexDigits) => MetaChar("x" + hexDigits, loc) }
 
   /** Parse a unicode character `\ uhhhh`
     * @return
@@ -221,8 +230,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"\ u0020"`
     */
-  def charUnicode[A: P]: P[MetaChar] = Indexed("\\u" ~ hexDigit.rep(exactly = 4).!)
-    .map { case (loc, hexDigits) => MetaChar("u" + hexDigits, loc) }
+  protected val charUnicode: P[MetaChar] =
+    indexed(P.string("\\u") *> hexdig.repExactlyAs[String](4))
+      .map { case (loc, hexDigits) => MetaChar("u" + hexDigits, loc) }
 
   /** Parse a character with a code point `\x{h...h}`, where Character.MIN_CODE_POINT <= 0xh...h <=
     * Character.MAX_CODE_POINT and x is [[weaponregex.internal.parser.Parser#codePointEscChar]]
@@ -233,14 +243,12 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @see
     *   [[weaponregex.internal.parser.Parser#codePointEscChar]]
     */
-  def charCodePoint[A: P]: P[MetaChar] =
-    Indexed(s"\\$codePointEscChar" ~ "{" ~ hexDigit.rep(1).! ~ "}")
-      .map {
-        case (loc, hexDigits) if java.lang.Character.isValidCodePoint(Integer.parseInt(hexDigits, 16)) =>
-          MetaChar(s"$codePointEscChar{$hexDigits}", loc)
-        case _ =>
-          Fail
-          null
+  protected val charCodePoint: P[MetaChar] =
+    indexed(P.defer(hexdig.rep.string.between(P.string(s"\\$codePointEscChar{"), P.char('}'))))
+      .flatMap { case (loc, hexDigits) =>
+        if (java.lang.Character.isValidCodePoint(Integer.parseInt(hexDigits, 16)))
+          P.pure(MetaChar(s"$codePointEscChar{$hexDigits}", loc))
+        else P.failWith(s"Invalid code point: $hexDigits")
       }
 
   /** Used to consume a hexadecimal escape character `\ x` or `\ u` when all other hex related cases are checked and
@@ -248,10 +256,8 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @return
     *   a `null` dummy
     */
-  def hexEscCharConsumer[A: P]: P[RegexTree] = {
-    P("\\" ~ CharIn("xu"))./
-    null
-  }
+  protected val hexEscCharConsumer: P[RegexTree] =
+    P.stringIn(Set("\\x", "\\u")).void.flatMap(_ => P.fail)
 
   /** Parse a character range inside a character class
     * @return
@@ -259,14 +265,15 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"a-z"`
     */
-  def range[A: P]: P[Range] = Indexed(charClassCharLiteral ~ "-" ~ charClassCharLiteral)
-    .map { case (loc, (from, to)) => Range(from, to, loc) }
+  protected val range: P[Range] = indexed(
+    P.defer(charClassCharLiteral ~ (P.char('-') *> charClassCharLiteral))
+  ).map { case (loc, (from, to)) => Range(from, to, loc) }
 
   /** Parse special cases of a character literal in a character class
     * @return
     *   The captured character as a string
     */
-  def charClassCharLiteralSpecialCases[A: P]: P[String] = Fail
+  protected val charClassCharLiteralSpecialCases: P[Char] = P.fail
 
   /** Parse a single literal character that is allowed to be in a character class
     * @return
@@ -276,17 +283,25 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @see
     *   [[weaponregex.internal.parser.Parser.charClassSpecialChars]]
     */
-  def charClassCharLiteral[A: P]: P[Character] =
-    Indexed(CharPred(!charClassSpecialChars.contains(_)).! | charClassCharLiteralSpecialCases)
-      .map { case (loc, c) => Character(c.head, loc) }
+  protected val charClassCharLiteral: P[Character] = indexed(
+    P.defer(P.charWhere(c => !charClassSpecialChars.contains(c)) | charClassCharLiteralSpecialCases)
+  ).map { case (loc, c) => Character(c, loc) }
 
   /** Intermediate parsing rule for character class item tokens which can parse either `charClass`,
     * `preDefinedCharClass`, `metaCharacter`, `range`, `quoteChar`, or `charClassCharLiteral`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def classItem[A: P]: P[RegexTree] = P(
-    charClass | preDefinedCharClass | unicodeCharClass | metaCharacter | range | quoteChar | charClassCharLiteral
+  protected val classItem: P[RegexTree] = P.defer(
+    P.oneOf(
+      charClass.backtrack ::
+        preDefinedCharClass.backtrack ::
+        unicodeCharClass.backtrack ::
+        metaCharacter.backtrack ::
+        range.backtrack ::
+        quoteChar.backtrack ::
+        charClassCharLiteral :: Nil
+    )
   )
 
   /** Parse a character class
@@ -295,8 +310,15 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"[abc]"`
     */
-  def charClass[A: P]: P[CharacterClass] = Indexed("[" ~ "^".!.? ~ classItem.rep(minCharClassItem) ~ "]")
-    .map { case (loc, (hat, nodes)) => CharacterClass(nodes, loc, isPositive = hat.isEmpty) }
+  protected val charClass: P[CharacterClass] = {
+    val items: P0[List[RegexTree]] = P.defer0(
+      if (minCharClassItem == 0) classItem.rep0
+      else classItem.rep.map(_.toList)
+    )
+    indexed((P.char('^').? ~ items).with1.between(P.char('['), P.char(']'))).map { case (loc, (hat, nodes)) =>
+      CharacterClass(nodes, loc, isPositive = hat.isEmpty)
+    }
+  }
 
   /** Parse an any(dot) (`.`) predefined character class
     * @return
@@ -304,8 +326,7 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"."`
     */
-  def anyDot[A: P]: P[AnyDot] = Indexed(P("."))
-    .map { case (loc, _) => AnyDot(loc) }
+  protected val anyDot: P[AnyDot] = indexed(P.char('.').void).map { case (loc, _) => AnyDot(loc) }
 
   /** Parse a predefined character class
     * @return
@@ -315,9 +336,13 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @see
     *   [[weaponregex.internal.parser.Parser.predefCharClassChars]]
     */
-  def preDefinedCharClass[A: P]: P[PredefinedCharClass] =
-    Indexed("""\""" ~ CharPred(predefCharClassChars.contains(_)).!)
+  protected val preDefinedCharClass: P[PredefinedCharClass] =
+    indexed(backslash *> P.defer(P.charIn(predefCharClassChars)))
       .map { case (loc, c) => PredefinedCharClass(c, loc) }
+
+  protected val propName: P[String] =
+    (alpha.void ~
+      (alpha.void | digit.void | P.char('_')).rep).string
 
   /** Parse a unicode character class with lone property
     *
@@ -328,12 +353,10 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @note
     *   This does not check for the validity of the property inside `\p{}`
     */
-  def unicodeCharClassLoneProperty[A: P]: P[UnicodeCharClass] =
-    Indexed(
-      """\""" ~ CharIn("pP").! ~ "{" ~
-        (CharIn("a-z", "A-Z") ~ CharIn("a-z", "A-Z", "0-9", "_").rep).! ~ "}"
-    )
-      .map { case (loc, (p, property)) => UnicodeCharClass(property, loc, p == "p") }
+  protected val unicodeCharClassLoneProperty: P[UnicodeCharClass] =
+    indexed(
+      backslash *> P.charIn('p', 'P') ~ (propName.between(P.char('{'), P.char('}')))
+    ).map { case (loc, (p, property)) => UnicodeCharClass(property, loc, p == 'p') }
 
   /** Parse a unicode character class with property and value
     *
@@ -344,13 +367,14 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @note
     *   This does not check for the validity of the property inside `\p{}`
     */
-  def unicodeCharClassPropertyValue[A: P]: P[UnicodeCharClass] =
-    Indexed(
-      """\""" ~ CharIn("pP").! ~ "{" ~
-        (CharIn("a-z", "A-Z") ~ CharIn("a-z", "A-Z", "0-9", "_").rep).! ~ "=" ~
-        (CharIn("a-z", "A-Z") ~ CharIn("a-z", "A-Z", "0-9", "_").rep).! ~ "}"
-    )
-      .map { case (loc, (p, property, propValue)) => UnicodeCharClass(property, loc, p == "p", Some(propValue)) }
+  protected val unicodeCharClassPropertyValue: P[UnicodeCharClass] = {
+    indexed(
+      backslash *> P.charIn('p', 'P') ~
+        ((propName <* P.char('=')) ~ propName).between(P.char('{'), P.char('}'))
+    ).map { case (loc, (p, (property, propValue))) =>
+      UnicodeCharClass(property, loc, p == 'p', Some(propValue))
+    }
+  }
 
   /** Parse a unicode character class
     *
@@ -361,7 +385,8 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @note
     *   This does not check for the validity of the property inside `\p{}`
     */
-  def unicodeCharClass[A: P]: P[UnicodeCharClass] = P(unicodeCharClassPropertyValue | unicodeCharClassLoneProperty)
+  protected val unicodeCharClass: P[UnicodeCharClass] =
+    unicodeCharClassPropertyValue.backtrack | unicodeCharClassLoneProperty
 
   /** A higher order parser that add [[weaponregex.internal.model.regextree.QuantifierType]] information of the parse of
     * the given (quantifier) parser
@@ -371,13 +396,13 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     *   A tuple of the return of the given (quantifier) parser `p`, and its
     *   [[weaponregex.internal.model.regextree.QuantifierType]]
     */
-  def quantifierType[A: P, T](p: => P[T]): P[(T, QuantifierType)] = P(p ~ CharIn("?+").!.?)
-    .map { case (pp, optionQType) =>
+  protected def quantifierType[A](p: P[A]): P[(A, QuantifierType)] =
+    (p ~ P.charIn('?', '+').?).map { case (result, optQ) =>
       (
-        pp,
-        optionQType match {
-          case Some("?") => ReluctantQuantifier
-          case Some("+") => PossessiveQuantifier
+        result,
+        optQ match {
+          case Some('?') => ReluctantQuantifier
+          case Some('+') => PossessiveQuantifier
           case _         => GreedyQuantifier
         }
       )
@@ -389,23 +414,25 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"a*"`
     */
-  def quantifierShort[A: P]: P[RegexTree] = Indexed(quantifierType(elementaryRE ~ CharIn("?*+").!))
-    .map { case (loc, ((expr, q), quantifierType)) =>
-      q match {
-        case "?"   => ZeroOrOne(expr, loc, quantifierType)
-        case "*"   => ZeroOrMore(expr, loc, quantifierType)
-        case "+"   => OneOrMore(expr, loc, quantifierType)
-        case other =>
-          // This case should never happen since the parser only allows "?", "*", or "+" as `q`
-          throw new IllegalStateException(s"Unexpected quantifier character: $other")
+  protected val quantifierShort: P[RegexTree] =
+    indexed(quantifierType(P.defer(elementaryRE) ~ P.charIn('?', '*', '+')))
+      .flatMap { case (loc, ((expr, q), quantifierType)) =>
+        q match {
+          case '?'   => P.pure(ZeroOrOne(expr, loc, quantifierType))
+          case '*'   => P.pure(ZeroOrMore(expr, loc, quantifierType))
+          case '+'   => P.pure(OneOrMore(expr, loc, quantifierType))
+          case other =>
+            // This case should never happen since the parser only allows "?", "*", or "+" as `q`
+            P.failWith(s"Unexpected quantifier character: $other")
+        }
       }
-    }
 
   /** Parse the tail part of a long quantifier
     * @return
     *   A tuple of the quantifier minimum and optional maximum part
     */
-  def quantifierLongTail[A: P]: P[(Int, Option[Option[Int]])] = number ~ ("," ~ number.?).? ~ "}"
+  protected val quantifierLongTail: P[(Int, Option[Option[Int]])] =
+    number ~ (P.char(',') *> number.?).? <* P.char('}')
 
   /** Parse a (full) quantifier (`{n}`, `{n,}`, `{n,m}`)
     * @return
@@ -413,27 +440,25 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"a{1}"`
     */
-  // `.filter()` function from fastparse is wrongly mutated by Stryker4s into `.filterNot()` which does not exist in fastparse
-  @SuppressWarnings(Array("stryker4s.mutation.MethodExpression"))
-  def quantifierLong[A: P]: P[Quantifier] =
-    Indexed(quantifierType(elementaryRE ~ "{" ~ quantifierLongTail))
-      .filter {
-        case (_, ((_, (min, Some(Some(max)))), _)) => min <= max
-        case _                                     => true
-      }
-      .map { case (loc, ((expr, (num, optionMax)), quantifierType)) =>
-        optionMax match {
-          case None            => Quantifier(expr, num, loc, quantifierType)
-          case Some(None)      => Quantifier(expr, num, Quantifier.Infinity, loc, quantifierType)
-          case Some(Some(max)) => Quantifier(expr, num, max, loc, quantifierType)
-        }
+  protected val quantifierLong: P[Quantifier] =
+    indexed(quantifierType(P.defer(elementaryRE) ~ (P.char('{') *> quantifierLongTail)))
+      .flatMap {
+        case (_, ((_, (num, Some(Some(max)))), _)) if num > max =>
+          P.failWith(s"Invalid quantifier: minimum $num is greater than maximum $max")
+        case (loc, ((expr, (num, optionMax)), qt)) =>
+          val q = optionMax match {
+            case None            => Quantifier(expr, num, loc, qt)
+            case Some(None)      => Quantifier(expr, num, Quantifier.Infinity, loc, qt)
+            case Some(Some(max)) => Quantifier(expr, num, max, loc, qt)
+          }
+          P.pure(q)
       }
 
   /** Intermediate parsing rule for quantifier tokens which can parse either `quantifierShort` or `quantifierLong`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def quantifier[A: P]: P[RegexTree] = P(quantifierShort | quantifierLong)
+  protected val quantifier: P[RegexTree] = quantifierShort.backtrack | quantifierLong.backtrack
 
   /** Parse a capturing group
     * @return
@@ -441,8 +466,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"(a)"`
     */
-  def group[A: P]: P[Group] = Indexed("(" ~ RE ~ ")")
-    .map { case (loc, expr) => Group(expr, isCapturing = true, loc) }
+  protected val group: P[Group] =
+    indexed(P.defer0(RE).with1.between(P.char('('), P.char(')')))
+      .map { case (loc, expr) => Group(expr, isCapturing = true, loc) }
 
   /** Parse a group name
     * @return
@@ -450,7 +476,7 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"name1"`
     */
-  def groupName[A: P]: P[String]
+  protected val groupName: P[String]
 
   /** Parse a named-capturing group
     * @return
@@ -458,8 +484,12 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"(?<name1>hello)"`
     */
-  def namedGroup[A: P]: P[NamedGroup] = Indexed("(?<" ~ groupName ~ ">" ~ RE ~ ")")
-    .map { case (loc, (name, expr)) => NamedGroup(expr, name, loc) }
+  protected val namedGroup: P[NamedGroup] =
+    indexed(
+      (P.defer(groupName).between(P.char('<'), P.char('>')) ~ P.defer0(RE))
+        .between(P.string("(?"), P.char(')'))
+    )
+      .map { case (loc, (name, expr)) => NamedGroup(expr, name, loc) }
 
   /** Parse a non-capturing group
     * @return
@@ -467,8 +497,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"(?:hello)"`
     */
-  def nonCapturingGroup[A: P]: P[Group] = Indexed("(?:" ~ RE ~ ")")
-    .map { case (loc, expr) => Group(expr, isCapturing = false, loc) }
+  protected val nonCapturingGroup: P[Group] =
+    indexed(P.defer0(RE).with1.between(P.string("(?:"), P.char(')')))
+      .map { case (loc, expr) => Group(expr, isCapturing = false, loc) }
 
   /** Parse flag literal characters given a string contains all allowed flags
     * @param fs
@@ -480,10 +511,11 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @note
     *   This is a Scala/Java-only regex syntax
     */
-  // `.filter()` function from fastparse is wrongly mutated by Stryker4s into `.filterNot()` which does not exist in fastparse
+  // `.filter()` function from cats-parse is wrongly mutated by Stryker4s into `.filterNot()` which does not exist in cats-parse
   @SuppressWarnings(Array("stryker4s.mutation.MethodExpression"))
-  def flags[A: P](fs: String): P[Flags] = Indexed(charLiteral.filter(c => fs.contains(c.char)).rep)
-    .map { case (loc, fs) => Flags(fs, loc) }
+  protected def flags(fs: String): P0[Flags] =
+    indexed0(charLiteral.filter(c => fs.contains(c.char)).backtrack.rep0)
+      .map { case (loc, fs) => Flags(fs, loc) }
 
   /** Parse a flag toggle (`idmsuxU-idmsuxU`)
     * @return
@@ -493,8 +525,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @note
     *   This is a Scala/Java-only regex syntax
     */
-  def flagToggle[A: P](fs: String): P[FlagToggle] = Indexed(flags(fs) ~ "-".!.? ~ flags(fs))
-    .map { case (loc, (onFlags, dash, offFlags)) => FlagToggle(onFlags, dash.isDefined, offFlags, loc) }
+  protected def flagToggle(fs: String): P0[FlagToggle] =
+    indexed0((flags(fs) ~ P.char('-').? ~ flags(fs)).map { case ((on, dash), off) => (on, dash, off) })
+      .map { case (loc, (onFlags, dash, offFlags)) => FlagToggle(onFlags, dash.isDefined, offFlags, loc) }
 
   /** Parse a flag toggle group
     * @return
@@ -504,8 +537,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @note
     *   This is a Scala/Java-only regex syntax
     */
-  def flagToggleGroup[A: P]: P[FlagToggleGroup] = Indexed("(?" ~ flagToggle("idmsuxU") ~ ")")
-    .map { case (loc, ft) => FlagToggleGroup(ft, loc) }
+  protected val flagToggleGroup: P[FlagToggleGroup] =
+    indexed(flagToggle("idmsuxU").with1.between(P.string("(?"), P.char(')')))
+      .map { case (loc, ft) => FlagToggleGroup(ft, loc) }
 
   /** Parse a non-capturing group with flags
     * @return
@@ -515,8 +549,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @note
     *   This is a Scala/Java-only regex syntax
     */
-  def flagNCGroup[A: P]: P[FlagNCGroup] = Indexed("(?" ~ flagToggle("idmsux") ~ ":" ~ RE ~ ")")
-    .map { case (loc, (ft, expr)) => FlagNCGroup(ft, expr, loc) }
+  protected val flagNCGroup: P[FlagNCGroup] =
+    indexed((flagToggle("idmsux") ~ (P.char(':') *> P.defer0(RE))).with1.between(P.string("(?"), P.char(')')))
+      .map { case (loc, (ft, expr)) => FlagNCGroup(ft, expr, loc) }
 
   /** Parse a positive or negative lookahead or lookbehind
     * @return
@@ -524,8 +559,11 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"(?=abc)"` (positive lookahead)
     */
-  def lookaround[A: P]: P[Lookaround] = Indexed("(?" ~ "<".!.? ~ CharIn("=!").! ~ RE ~ ")")
-    .map { case (loc, (angleBracket, posNeg, expr)) => Lookaround(expr, posNeg == "=", angleBracket.isEmpty, loc) }
+  protected val lookaround: P[Lookaround] =
+    indexed((P.char('<').? ~ P.charIn('=', '!') ~ P.defer0(RE)).with1.between(P.string("(?"), P.char(')'))).map {
+      case (loc, ((angleBracket, posNeg), expr)) =>
+        Lookaround(expr, posNeg == '=', angleBracket.isEmpty, loc)
+    }
 
   /** Parse an independent non-capturing group
     *
@@ -536,23 +574,23 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @note
     *   This is a Scala/Java-only regex syntax
     */
-  def atomicGroup[A: P]: P[AtomicGroup] = Indexed("(?>" ~ RE ~ ")")
-    .map { case (loc, expr) => AtomicGroup(expr, loc) }
+  protected val atomicGroup: P[AtomicGroup] =
+    indexed(P.defer0(RE).with1.between(P.string("(?>"), P.char(')')))
+      .map { case (loc, expr) => AtomicGroup(expr, loc) }
 
   /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup` or
     * `lookaround`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def specialConstruct[A: P]: P[RegexTree] = P(
-    namedGroup | nonCapturingGroup | lookaround
-  )
+  protected val specialConstruct: P[RegexTree] =
+    P.oneOf(namedGroup.backtrack :: nonCapturingGroup.backtrack :: lookaround.backtrack :: Nil)
 
   /** Intermediate parsing rule for capturing-related tokens which can parse either `group` or `specialConstruct`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def capturing[A: P]: P[RegexTree] = P(group | specialConstruct)
+  protected val capturing: P[RegexTree] = P.defer(group.backtrack | specialConstruct)
 
   /** Parse a reference to a named capturing group
     * @return
@@ -560,8 +598,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"\k<name1>"`
     */
-  def nameReference[A: P]: P[NameReference] = Indexed("""\k<""" ~ groupName ~ ">")
-    .map { case (loc, name) => NameReference(name, loc) }
+  protected val nameReference: P[NameReference] =
+    indexed(P.defer(groupName).between(P.string("\\k<"), P.char('>')))
+      .map { case (loc, name) => NameReference(name, loc) }
 
   /** Parse a numbered reference to a capture group
     * @return
@@ -569,14 +608,15 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"\13"`
     */
-  def numReference[A: P]: P[NumberReference] = Indexed("""\""" ~ (CharIn("1-9") ~ CharIn("0-9").rep).!)
-    .map { case (loc, num) => NumberReference(num.toInt, loc) }
+  protected val numReference: P[NumberReference] =
+    indexed(backslash *> (Numbers.nonZeroDigit ~ Numbers.digit.rep0).string)
+      .map { case (loc, num) => NumberReference(num.toInt, loc) }
 
   /** Intermediate parsing rule for reference tokens which can parse either `nameReference` or `numReference`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def reference[A: P]: P[RegexTree] = P(nameReference | numReference)
+  protected val reference: P[RegexTree] = nameReference.backtrack | numReference.backtrack
 
   /** Parse a quoted character (any character)
     * @return
@@ -584,8 +624,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"\$"`
     */
-  def quoteChar[A: P]: P[QuoteChar] = Indexed("""\""" ~ AnyChar.!)
-    .map { case (loc, char) => QuoteChar(char.head, loc) }
+  protected val quoteChar: P[QuoteChar] =
+    indexed(backslash *> P.anyChar)
+      .map { case (loc, char) => QuoteChar(char, loc) }
 
   /** Parse a 'long' quote, using `\Q` and `\E`
     * @return
@@ -593,29 +634,44 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"\Qquoted\E"`
     */
-  def quoteLong[A: P]: P[Quote] = Indexed("""\Q""" ~ (!"""\E""" ~ AnyChar).rep.! ~ """\E""".!.?)
-    .map { case (loc, (str, end)) => Quote(str, end.isDefined, loc) }
+  protected val quoteLong: P[Quote] =
+    indexed(
+      P.string("\\Q") *>
+        (P.until0(P.string("\\E")) ~ P.string("\\E").?)
+    ).map { case (loc, (str, end)) => Quote(str, end.isDefined, loc) }
 
   /** Intermediate parsing rule for quoting tokens which can parse either `quoteLong` or `quoteChar`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def quote[A: P]: P[RegexTree] = P(quoteLong | quoteChar)
+  protected val quote: P[RegexTree] = quoteLong.backtrack | quoteChar
 
   /** Intermediate parsing rule which can parse either `capturing`, `anyDot`, `preDefinedCharClass`, `boundary`,
     * `charClass`, `reference`, `character` or `quote`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def elementaryRE[A: P]: P[RegexTree] = P(
-    capturing | anyDot | preDefinedCharClass | unicodeCharClass | boundary | charClass | reference | character | quote
-  )
+  protected val elementaryRE: P[RegexTree] =
+    P.defer(
+      P.oneOf(
+        capturing.backtrack ::
+          anyDot ::
+          preDefinedCharClass.backtrack ::
+          unicodeCharClass.backtrack ::
+          boundary.backtrack ::
+          charClass.backtrack ::
+          reference.backtrack ::
+          character.backtrack ::
+          hexEscCharConsumer ::
+          quote :: Nil
+      )
+    )
 
   /** Intermediate parsing rule which can parse either `quantifier` or `elementaryRE`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def basicRE[A: P]: P[RegexTree] = P(quantifier | elementaryRE)
+  protected val basicRE: P[RegexTree] = P.defer(quantifier.backtrack | elementaryRE)
 
   /** Parse a concatenation of `basicRE`s
     * @return
@@ -623,8 +679,9 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"abc"`
     */
-  def concat[A: P]: P[Concat] = Indexed(basicRE.rep(2))
-    .map { case (loc, nodes) => Concat(nodes, loc) }
+  protected val concat: P[Concat] =
+    indexed(basicRE.rep(min = 2))
+      .map { case (loc, nodes) => Concat(nodes.toList, loc) }
 
   /** Parse an empty string
     *
@@ -633,14 +690,14 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `""`
     */
-  def empty[A: P]: P[Empty] = Indexed("")
-    .map { case (loc, _) => Empty(loc) }
+  protected val empty: P0[Empty] =
+    indexed0(P.unit).map { case (loc, _) => Empty(loc) }
 
   /** Intermediate parsing rule which can parse either `concat`, `basicRE` or `empty`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  def simpleRE[A: P]: P[RegexTree] = P(concat | basicRE | empty)
+  protected val simpleRE: P0[RegexTree] = concat.backtrack | basicRE | empty
 
   /** Parse an 'or' (`|`) of `simpleRE`
     * @return
@@ -648,8 +705,10 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   `"a|b|c"`
     */
-  def or[A: P]: P[Or] = Indexed(simpleRE.rep(2, sep = "|"))
-    .map { case (loc, nodes) => Or(nodes, loc) }
+  protected val or: P[Or] =
+    indexed(
+      simpleRE.with1 ~ (P.char('|') *> simpleRE).rep
+    ).map { case (loc, (first, rest)) => Or(first :: rest.toList, loc) }
 
   /** The top-level parsing rule which can parse either `or` or `simpleRE`
     * @return
@@ -657,21 +716,13 @@ abstract private[weaponregex] class Parser(val pattern: String) {
     * @example
     *   any supported regex
     */
-  def RE[A: P]: P[RegexTree] = P(or | simpleRE)
-
-  /** The entry point of the parser that should parse from the start to the end of the regex string
-    * @return
-    *   [[weaponregex.internal.model.regextree.RegexTree]] tree
-    */
-  def entry[A: P]: P[RegexTree] = P(Start ~ RE ~ End)
+  protected val RE: P0[RegexTree] = or.backtrack | simpleRE
 
   /** Parse the given regex pattern
     * @return
     *   A `Right` of parsed [[weaponregex.internal.model.regextree.RegexTree]] if can be parsed, a `Left` with the error
     *   message otherwise
     */
-  def parse: Either[String, RegexTree] = fastparse.parse(pattern, entry(_)) match {
-    case Parsed.Success(regexTree: RegexTree, _) => Right(regexTree)
-    case f: Parsed.Failure                       => Left(ErrorMessage.parserErrorHeader + f.msg)
-  }
+  final def parse(pattern: String): Either[String, RegexTree] =
+    RE.parseAll(pattern).left.map(err => ErrorMessage.parserErrorHeader + err.show)
 }

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
@@ -1,64 +1,58 @@
 package weaponregex.internal.parser
 
-import fastparse.*
+import cats.parse.Rfc5234.*
+import cats.parse.{Numbers, Parser as P}
 import weaponregex.internal.model.regextree.*
 
-import NoWhitespace.*
-
-/** Concrete parser for JS flavor of regex
-  * @param pattern
-  *   The regex pattern to be parsed
-  * @param flags
-  *   The regex flags to be used
+/** Parser instance for JS flavor of regex
+  * @param unicodeMode
+  *   Whether the parser should be in Unicode mode, which is determined by the presence of `u` or `v` flag.
   * @note
   *   This class constructor is private, instances must be created using the companion
-  *   [[weaponregex.internal.parser.Parser]] object
+  *   [[weaponregex.internal.parser.ParserJS]] object
   * @see
   *   [[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet]]
   * @see
   *   [[https://tc39.es/ecma262/multipage/text-processing.html#sec-patterns]]
   */
-private[weaponregex] class ParserJS private[parser] (pattern: String, val flags: Option[String] = None)
-    extends Parser(pattern) {
-
-  /** Whether the flags contain the `u` or `v` flag for Unicode mode */
-  private val unicodeMode: Boolean = flags.exists(f => f.contains("u") || f.contains("v"))
+private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean) extends Parser {
 
   /** Regex special characters
     */
-  override val specialChars: String = """()[{\.^$|?*+"""
+  override protected val specialChars: String = """()[{\.^$|?*+"""
 
   /** Special characters within a character class
     */
-  override val charClassSpecialChars: String = """]\"""
+  override protected val charClassSpecialChars: String = """]\"""
 
   /** Allowed boundary meta-characters
     */
-  override val boundaryMetaChars: String = "bB"
+  override protected val boundaryMetaChars: String = "bB"
 
   /** Allowed escape characters
     */
-  override val escapeChars: String = "\\\\tnrf" // fastparse needs `////` for a single backslash
+  override protected val escapeChars: String = "\\\\tnrf" // need `////` for a single backslash
 
   /** Allowed predefined character class characters
     */
-  override val predefCharClassChars: String = "dDsSvwW"
+  override protected val predefCharClassChars: String = "dDsSvwW"
 
   /** Minimum number of character class items of a valid character class
     */
-  override val minCharClassItem: Int = 0
+  override protected val minCharClassItem: Int = 0
 
   /** The escape character used with a code point
     * @example
     *   `\ x{h..h}` or `\ u{h..h}`
     */
-  override val codePointEscChar: String = "u"
+  override protected val codePointEscChar: Char = 'u'
 
   /** Parse special cases of a character literal
     * @return
     *   The captured character as a string
     */
-  override def charLiteralSpecialCases[A: P]: P[String] = P("{".! ~ !quantifierLongTail)
+  override protected val charLiteralSpecialCases: P[Char] =
+    P.char('{').as('{') <* P.not(quantifierLongTail)
 
   /** Intermediate parsing rule for character class item tokens which can parse either `preDefinedCharClass`,
     * `metaCharacter`, `range`, `quoteChar`, or `charClassCharLiteral`
@@ -67,11 +61,24 @@ private[weaponregex] class ParserJS private[parser] (pattern: String, val flags:
     * @note
     *   Nested character class is a Scala/Java-only regex syntax
     */
-  override def classItem[A: P]: P[RegexTree] =
+  override protected val classItem: P[RegexTree] =
     if (unicodeMode)
-      P(preDefinedCharClass | unicodeCharClass | metaCharacter | range | quoteChar | charClassCharLiteral)
+      P.oneOf(
+        preDefinedCharClass.backtrack ::
+          unicodeCharClass.backtrack ::
+          P.defer(metaCharacter).backtrack ::
+          range.backtrack ::
+          quoteChar.backtrack ::
+          charClassCharLiteral :: Nil
+      )
     else
-      P(preDefinedCharClass | metaCharacter | range | quoteChar | charClassCharLiteral)
+      P.oneOf(
+        preDefinedCharClass.backtrack ::
+          P.defer(metaCharacter).backtrack ::
+          range.backtrack ::
+          quoteChar.backtrack ::
+          charClassCharLiteral :: Nil
+      )
 
   /** Parse a group name
     * @return
@@ -79,8 +86,9 @@ private[weaponregex] class ParserJS private[parser] (pattern: String, val flags:
     * @example
     *   `"name1"`
     */
-  override def groupName[A: P]: P[String] =
-    P(CharIn("a-z", "A-Z", "_") ~ CharIn("a-z", "A-Z", "0-9", "_").rep).!
+  override protected val groupName: P[String] =
+    ((alpha.void | P.char('_')) ~
+      (alpha.void | digit.void | P.char('_')).rep).string
 
   /** Parse a quoted character (any character). If [[weaponregex.internal.parser.ParserJS unicodeMode]] is true, only
     * the following characters are allowed: `^ $ \ . * + ? ( ) [ ] { } |` or `/`
@@ -89,10 +97,11 @@ private[weaponregex] class ParserJS private[parser] (pattern: String, val flags:
     * @example
     *   `"\$"`
     */
-  override def quote[A: P]: P[QuoteChar] = if (unicodeMode)
-    Indexed("""\""" ~ CharIn("""^$\.*+?()[]{}|/""").!)
-      .map { case (loc, char) => QuoteChar(char.head, loc) }
-  else quoteChar
+  override protected val quote: P[RegexTree] =
+    if (unicodeMode)
+      indexed(P.char('\\') *> P.charIn("""^$\.*+?()[]{}|/"""))
+        .map { case (loc, char) => QuoteChar(char, loc) }
+    else quoteChar
 
   /** Parse a character with octal value `\n`, `\nn`, `\mnn` (0 <= m,n <= 9)
     *
@@ -104,33 +113,73 @@ private[weaponregex] class ParserJS private[parser] (pattern: String, val flags:
     *   This syntax will correctly match if 0 <= m <= 3, 0 <= n <= 7; but m and/or n outside of this range will still be
     *   parsable.
     */
-  override def charOct[A: P]: P[MetaChar] = Indexed("""\""" ~ CharIn("0-9").rep(min = 1, max = 3).!)
-    .map { case (loc, octDigits) => MetaChar(octDigits, loc) }
+  override protected val charOct: P[MetaChar] =
+    indexed(P.char('\\') *> Numbers.digit.rep(1, 3).string)
+      .map { case (loc, octDigits) => MetaChar(octDigits, loc) }
 
   /** Intermediate parsing rule for reference tokens which can parse only `nameReference`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  override def reference[A: P]: P[RegexTree] = nameReference
+  override protected val reference: P[RegexTree] = nameReference
 
   /** Intermediate parsing rule for meta-character tokens which can parse either `charOct`, `charHex`, `charUnicode` or
     * `escapeChar`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  override def metaCharacter[A: P]: P[RegexTree] =
-    if (unicodeMode) P(charOct | charHex | charUnicode | charCodePoint | escapeChar | controlChar)
-    else P(charOct | charHex | escapeChar | controlChar)
+  override protected val metaCharacter: P[RegexTree] =
+    if (unicodeMode)
+      P.oneOf(
+        charOct.backtrack ::
+          charHex.backtrack ::
+          charUnicode.backtrack ::
+          charCodePoint.backtrack ::
+          escapeChar.backtrack ::
+          controlChar.backtrack :: Nil
+      )
+    else P.oneOf(charOct.backtrack :: charHex.backtrack :: escapeChar.backtrack :: controlChar.backtrack :: Nil)
 
   /** Intermediate parsing rule which can parse either `capturing`, `anyDot`, `preDefinedCharClass`, `boundary`,
     * `charClass`, `reference`, `character` or `quote`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  override def elementaryRE[A: P]: P[RegexTree] =
+  override protected val elementaryRE: P[RegexTree] =
     if (unicodeMode)
-      P(
-        capturing | anyDot | preDefinedCharClass | unicodeCharClass | boundary | charClass | reference | character | quote
+      P.oneOf(
+        capturing.backtrack ::
+          anyDot.backtrack ::
+          preDefinedCharClass.backtrack ::
+          unicodeCharClass.backtrack ::
+          boundary.backtrack ::
+          charClass.backtrack ::
+          reference.backtrack ::
+          character.backtrack ::
+          quote :: Nil
       )
-    else P(capturing | anyDot | preDefinedCharClass | boundary | charClass | reference | character | quote)
+    else
+      P.oneOf(
+        capturing.backtrack ::
+          anyDot.backtrack ::
+          preDefinedCharClass.backtrack ::
+          boundary.backtrack ::
+          charClass.backtrack ::
+          reference.backtrack ::
+          character.backtrack ::
+          quote :: Nil
+      )
+}
+
+object ParserJS {
+
+  /** Whether the flags contain the `u` or `v` flag for Unicode mode */
+  private def unicodeMode(flags: Option[String]): Boolean = flags.exists(f => f.contains('u') || f.contains('v'))
+
+  // Create lazy instances so all parsers are only instantiated once
+  private lazy val unicodeParser: ParserJS = new ParserJS(true)
+  private lazy val nonUnicodeParser: ParserJS = new ParserJS(false)
+
+  private[parser] def apply(flags: Option[String] = None): ParserJS =
+    if (unicodeMode(flags)) unicodeParser else nonUnicodeParser
 }

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJVM.scala
@@ -1,50 +1,46 @@
 package weaponregex.internal.parser
 
-import fastparse.*
+import cats.parse.Rfc5234.*
+import cats.parse.{Numbers, Parser as P, Parser0 as P0}
 import weaponregex.internal.model.regextree.*
 
-import NoWhitespace.*
-
-/** Concrete parser for JVM flavor of regex
-  * @param pattern
-  *   The regex pattern to be parsed
+/** Parser instance for JVM flavor of regex
   * @note
-  *   This class constructor is private, instances must be created using the companion
-  *   [[weaponregex.internal.parser.Parser]] object
+  *   This object is private, instances must be accessed [[weaponregex.internal.parser.Parser]] object
   * @see
   *   [[https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html]]
   */
-private[weaponregex] class ParserJVM private[parser] (pattern: String) extends Parser(pattern) {
+private[weaponregex] object ParserJVM extends Parser {
 
   /** Regex special characters
     */
-  override val specialChars: String = """()[{\.^$|?*+"""
+  override protected val specialChars: String = """()[{\.^$|?*+"""
 
   /** Special characters within a character class
     */
-  override val charClassSpecialChars: String = """[]\&"""
+  override protected val charClassSpecialChars: String = """[]\&"""
 
   /** Allowed boundary meta-characters
     */
-  override val boundaryMetaChars: String = "bBAGzZ"
+  override protected val boundaryMetaChars: String = "bBAGzZ"
 
   /** Allowed escape characters
     */
-  override val escapeChars: String = "\\\\tnrfae" // fastparse needs `////` for a single backslash
+  override protected val escapeChars: String = "\\\\tnrfae" // fastparse needs `////` for a single backslash
 
   /** Allowed predefined character class characters
     */
-  override val predefCharClassChars: String = "dDhHsSvVwW"
+  override protected val predefCharClassChars: String = "dDhHsSvVwW"
 
   /** Minimum number of character class items of a valid character class
     */
-  override val minCharClassItem: Int = 1
+  override protected val minCharClassItem: Int = 1
 
   /** The escape character used with a code point
     * @example
     *   `\ x{h..h}` or `\ u{h..h}`
     */
-  override val codePointEscChar: String = "x"
+  override protected val codePointEscChar: Char = 'x'
 
   /** Parse a character with octal value `\0n`, `\0nn`, `\0mnn` (0 <= m <= 3, 0 <= n <= 7)
     *
@@ -53,15 +49,20 @@ private[weaponregex] class ParserJVM private[parser] (pattern: String) extends P
     * @example
     *   `"\012"`
     */
-  override def charOct[A: P]: P[MetaChar] =
-    Indexed("""\0""" ~ (CharIn("0-3") ~ CharIn("0-7").rep(exactly = 2) | CharIn("0-7").rep(min = 1, max = 2)).!)
-      .map { case (loc, octDigits) => MetaChar("0" + octDigits, loc) }
+  override protected val charOct: P[MetaChar] =
+    indexed(
+      P.string("\\0") *> (
+        (P.charIn('0' to '3') ~ P.charIn('0' to '7').repExactlyAs[String](2)).string.backtrack |
+          P.charIn('0' to '7').rep(1, 2).string
+      )
+    ).map { case (loc, octDigits) => MetaChar("0" + octDigits, loc) }
 
   /** Parse special cases of a character literal in a character class
     * @return
     *   The captured character as a string
     */
-  override def charClassCharLiteralSpecialCases[A: P]: P[String] = P("&".! ~ !"&")
+  override protected val charClassCharLiteralSpecialCases: P[Char] =
+    (P.char('&').as('&') <* P.not(P.char('&'))).backtrack
 
   /** Parse a character class content without the surround syntactical symbols, i.e. "naked"
     * @return
@@ -69,8 +70,9 @@ private[weaponregex] class ParserJVM private[parser] (pattern: String) extends P
     * @note
     *   This is used only inside the [[weaponregex.internal.parser.ParserJVM.charClassIntersection]]
     */
-  def charClassNaked[A: P]: P[CharacterClassNaked] = Indexed(classItem.rep(minCharClassItem))
-    .map { case (loc, nodes) => CharacterClassNaked(nodes, loc) }
+  private val charClassNaked: P[CharacterClassNaked] =
+    indexed(classItem.rep.map(_.toList))
+      .map { case (loc, nodes) => CharacterClassNaked(nodes, loc) }
 
   /** Parse a character class intersection used inside a character class.
     *
@@ -79,8 +81,8 @@ private[weaponregex] class ParserJVM private[parser] (pattern: String) extends P
     * @example
     *   `"abc&&[^bc]&&a-z"`
     */
-  def charClassIntersection[A: P]: P[CharClassIntersection] =
-    Indexed(charClassNaked.rep(2, sep = "&&"))
+  private val charClassIntersection: P[CharClassIntersection] =
+    indexed(charClassNaked.repSep(2, P.string("&&")).map(_.toList))
       .map { case (loc, nodes) => CharClassIntersection(nodes, loc) }
 
   /** Parse a character class
@@ -89,13 +91,12 @@ private[weaponregex] class ParserJVM private[parser] (pattern: String) extends P
     * @example
     *   `"[abc]"`
     */
-  override def charClass[A: P]: P[CharacterClass] =
-    Indexed(
-      "[" ~ "^".!.? ~ ((charClassIntersection.rep(exactly = 1): P[Seq[RegexTree]]) | classItem.rep(
-        minCharClassItem
-      )) ~ "]"
-    )
-      .map { case (loc, (hat, nodes)) => CharacterClass(nodes, loc, isPositive = hat.isEmpty) }
+  override protected val charClass: P[CharacterClass] = {
+    val content: P0[List[RegexTree]] = charClassIntersection.backtrack.map(ci => List(ci)) | classItem.rep.map(_.toList)
+    indexed(
+      (P.char('^').? ~ content).with1.between(P.char('['), P.char(']'))
+    ).map { case (loc, (hat, nodes)) => CharacterClass(nodes, loc, isPositive = hat.isEmpty) }
+  }
 
   /** Parse a group name
     * @return
@@ -103,15 +104,22 @@ private[weaponregex] class ParserJVM private[parser] (pattern: String) extends P
     * @example
     *   `"name1"`
     */
-  override def groupName[A: P]: P[String] =
-    P(CharIn("a-z", "A-Z") ~ CharIn("a-z", "A-Z", "0-9").rep).!
+  override protected val groupName: P[String] =
+    (alpha ~
+      (alpha | Numbers.digit).rep0).string
 
   /** Intermediate parsing rule for special construct tokens which can parse either `namedGroup`, `nonCapturingGroup`,
     * `flagToggleGroup`, `flagNCGroup`, `lookaround` or `atomicGroup`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  override def specialConstruct[A: P]: P[RegexTree] = P(
-    namedGroup | nonCapturingGroup | flagToggleGroup | flagNCGroup | lookaround | atomicGroup
-  )
+  override protected val specialConstruct: P[RegexTree] =
+    P.oneOf(
+      namedGroup.backtrack ::
+        nonCapturingGroup.backtrack ::
+        flagToggleGroup.backtrack ::
+        flagNCGroup.backtrack ::
+        lookaround.backtrack ::
+        atomicGroup.backtrack :: Nil
+    )
 }

--- a/core/src/main/scala/weaponregex/model/Location.scala
+++ b/core/src/main/scala/weaponregex/model/Location.scala
@@ -1,5 +1,7 @@
 package weaponregex.model
 
+import cats.parse.Caret
+
 import scala.scalajs.js.annotation.*
 
 /** A location in the source code which can span multiple lines and/or columns.
@@ -19,4 +21,8 @@ case class Location(start: Position, end: Position) {
 object Location {
   def apply(startLine: Int, startColumn: Int)(endLine: Int, endColumn: Int): Location =
     Location(Position(startLine, startColumn), Position(endLine, endColumn))
+
+  def fromCaret(start: Caret, end: Caret): Location =
+    Location(Position(start.line, start.col), Position(end.line, end.col))
+
 }

--- a/core/src/test/scala/weaponregex/internal/model/regextree/BoundaryNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/BoundaryNodeTest.scala
@@ -15,7 +15,7 @@ class BoundaryNodeTest extends munit.FunSuite {
   }
 
   test("Boundary build") {
-    val node1 = Boundary("G", LOCATION)
+    val node1 = Boundary('G', LOCATION)
     assertEquals(node1.build, """\G""")
   }
 }

--- a/core/src/test/scala/weaponregex/internal/model/regextree/PredefinedCharClassNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/PredefinedCharClassNodeTest.scala
@@ -5,12 +5,12 @@ import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class PredefinedCharClassNodeTest extends munit.FunSuite {
   test("PredefinedCharClass build") {
-    val node1 = PredefinedCharClass("w", LOCATION)
+    val node1 = PredefinedCharClass('w', LOCATION)
     assertEquals(node1.build, """\w""")
   }
 
   test("PredefinedCharClass build negated") {
-    val node2 = PredefinedCharClass("W", LOCATION)
+    val node2 = PredefinedCharClass('W', LOCATION)
     assertEquals(node2.build, """\W""")
   }
 

--- a/core/src/test/scala/weaponregex/internal/model/regextree/RegexTreeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/RegexTreeTest.scala
@@ -11,7 +11,7 @@ class RegexTreeTest extends munit.FunSuite {
       Seq(
         BOL(loc),
         OneOrMore(
-          PredefinedCharClass("w", loc),
+          PredefinedCharClass('w', loc),
           loc,
           GreedyQuantifier
         ),

--- a/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
@@ -127,8 +127,8 @@ trait ParserTest {
 
     pattern.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
-        case Boundary(str, _) => str.head == char
-        case _                => false
+        case Boundary(ch, _) => ch == char
+        case _               => false
       })
     }
 
@@ -211,7 +211,7 @@ trait ParserTest {
 
     pattern.init.tail.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
-        case PredefinedCharClass(charClass, _) => charClass.head == char
+        case PredefinedCharClass(charClass, _) => charClass == char
         case _                                 => false
       })
     }
@@ -282,7 +282,7 @@ trait ParserTest {
 
     controlChars zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
-        case ControlChar(controlChar, _) => controlChar.head == char
+        case ControlChar(controlChar, _) => controlChar == char
         case _                           => false
       })
     }
@@ -325,7 +325,7 @@ trait ParserTest {
     pattern.replace("""\""", "") zip parsedTree.children foreach { case (char, child) =>
       assert(clue(child) match {
         case _: AnyDot                         => char == '.'
-        case PredefinedCharClass(charClass, _) => charClass.head == char
+        case PredefinedCharClass(charClass, _) => charClass == char
         case _                                 => false
       })
     }


### PR DESCRIPTION
Switches over from fastparse to [cats-parse](https://typelevel.org/cats-parse/). Cats-parse is (slightly) better maintained under typelevel, and integrates well with the rest of the typelevel (Cats) ecosystem that Stryker4s also uses. Fastparse also uses lots of macros, which is good for performance, but not as great for new Scala versions or compiler speed.

Most parsers are now only instantiated once, with `val`, using deferred instances where necessary. Also a minor refactor to only instantiate the `Parser` class once (per flavor). Which will improve performance when parsing multiple regular expressions (don't have to instantiate a new parser for every expression)

Tests are mostly the same. Quick benchmarks show similar performance.