### PR TITLE
feat: improve Position/Location checks and tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,13 @@
 import org.scalajs.linker.interface.{ESFeatures, ESVersion}
 import org.typelevel.scalacoptions.{ScalaVersion, ScalacOption, ScalacOptions}
 import org.typelevel.sbt.tpolecat.DevMode
-import com.typesafe.tools.mima.core.{MissingMethodProblem, MissingTypesProblem, Problem, ProblemFilters}
+import com.typesafe.tools.mima.core.{
+  DirectMissingMethodProblem,
+  MissingMethodProblem,
+  MissingTypesProblem,
+  Problem,
+  ProblemFilters
+}
 
 // Skip publish root
 publish / skip := true
@@ -49,8 +55,12 @@ lazy val WeaponRegeX = projectMatrix
   .in(file("core"))
   .settings(
     name := "weapon-regex",
-    libraryDependencies += "org.typelevel" %%% "cats-parse" % "1.1.0",
-    libraryDependencies += "org.scalameta" %%% "munit" % "1.3.2" % Test,
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-parse" % "1.1.0",
+      "org.scalameta" %%% "munit" % "1.3.2" % Test,
+      "org.typelevel" %%% "cats-laws" % "2.13.0" % Test,
+      "org.typelevel" %%% "discipline-munit" % "2.0.0" % Test
+    ),
     tpolecatScalacOptions ++= Set(
       ScalacOptions.source3,
       ScalacOptions.release("8"),
@@ -65,7 +75,9 @@ lazy val WeaponRegeX = projectMatrix
       ProblemFilters.exclude[Problem]("weaponregex.internal.*"),
       // Adding fields to Mutant is not considered a breaking change
       ProblemFilters.exclude[MissingMethodProblem]("weaponregex.model.mutation.Mutant.*"),
-      ProblemFilters.exclude[MissingTypesProblem]("weaponregex.model.mutation.Mutant$")
+      ProblemFilters.exclude[MissingTypesProblem]("weaponregex.model.mutation.Mutant$"),
+      ProblemFilters.exclude[MissingTypesProblem]("weaponregex.model.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("weaponregex.model.*")
     )
   )
   .jvmPlatform(

--- a/core/src/main/scala/weaponregex/model/Location.scala
+++ b/core/src/main/scala/weaponregex/model/Location.scala
@@ -1,6 +1,9 @@
 package weaponregex.model
 
 import cats.parse.Caret
+import cats.syntax.order.*
+import cats.{Order, Show}
+import weaponregex.model.Position.*
 
 import scala.scalajs.js.annotation.*
 
@@ -13,6 +16,7 @@ import scala.scalajs.js.annotation.*
   */
 @JSExportAll
 case class Location(start: Position, end: Position) {
+  require(end >= start, s"Location end ${end.show} must be >= start ${start.show}")
   def show: String = s"[${start.show}, ${end.show})"
 }
 
@@ -24,5 +28,9 @@ object Location {
 
   def fromCaret(start: Caret, end: Caret): Location =
     Location(Position(start.line, start.col), Position(end.line, end.col))
+
+  implicit val showLocation: Show[Location] = _.show
+
+  implicit val locationOrder: Order[Location] = Order.by(l => (l.start, l.end))
 
 }

--- a/core/src/main/scala/weaponregex/model/Position.scala
+++ b/core/src/main/scala/weaponregex/model/Position.scala
@@ -1,5 +1,7 @@
 package weaponregex.model
 
+import cats.{Order, Show}
+
 import scala.scalajs.js.annotation.*
 
 /** A specific spot in the source code based on line and column. Stryker uses zero-based indexes. So the first character
@@ -12,5 +14,11 @@ import scala.scalajs.js.annotation.*
   */
 @JSExportAll
 case class Position(line: Int, column: Int) {
-  def show: String = s"$line:$column"
+  def show: String = s"${line}:${column}"
+}
+
+object Position {
+  implicit val showPosition: Show[Position] = _.show
+
+  implicit val positionOrder: Order[Position] = Order.by(p => (p.line, p.column))
 }

--- a/core/src/test/scala/weaponregex/arbitraries.scala
+++ b/core/src/test/scala/weaponregex/arbitraries.scala
@@ -1,0 +1,28 @@
+package weaponregex
+
+import org.scalacheck.*
+import weaponregex.model.*
+
+/** Instances for Scalacheck property testing. Used in tests to generate random values
+  */
+object arbitraries {
+  implicit def arbPosition: Arbitrary[Position] = Arbitrary {
+    for {
+      line <- Gen.posNum[Int]
+      column <- Gen.posNum[Int]
+    } yield Position(line, column)
+  }
+
+  implicit def arbLocation: Arbitrary[Location] = Arbitrary {
+    for {
+      startLine <- Gen.posNum[Int]
+      startColumn <- Gen.posNum[Int]
+      endLine <- Gen.choose(startLine, startLine + 10)
+      endColumn <- if (endLine > startLine) Gen.posNum[Int] else Gen.choose(startColumn, startColumn + 10)
+    } yield Location(Position(startLine, startColumn), Position(endLine, endColumn))
+  }
+
+  implicit def cogenPosition: Cogen[Position] = Cogen[(Int, Int)].contramap(p => (p.line, p.column))
+
+  implicit def cogenLocation: Cogen[Location] = Cogen[(Position, Position)].contramap(l => (l.start, l.end))
+}

--- a/core/src/test/scala/weaponregex/model/LocationTest.scala
+++ b/core/src/test/scala/weaponregex/model/LocationTest.scala
@@ -1,0 +1,21 @@
+package weaponregex.model
+
+import cats.kernel.laws.discipline.OrderTests
+import munit.DisciplineSuite
+import weaponregex.arbitraries.*
+
+class LocationTest extends DisciplineSuite {
+
+  checkAll("Location.OrderTests", OrderTests[Location].order)
+
+  test("Location start must be <= end") {
+    interceptMessage[IllegalArgumentException]("requirement failed: Location end 0:0 must be >= start 1:0") {
+      Location(Position(1, 0), Position(0, 0))
+    }
+  }
+
+  test("Location show should be in the format [start, end)") {
+    val location = Location(Position(1, 2), Position(3, 4))
+    assertEquals(location.show, "[1:2, 3:4)")
+  }
+}

--- a/core/src/test/scala/weaponregex/model/PositionTest.scala
+++ b/core/src/test/scala/weaponregex/model/PositionTest.scala
@@ -1,0 +1,11 @@
+package weaponregex.model
+
+import cats.kernel.laws.discipline.OrderTests
+import munit.DisciplineSuite
+import weaponregex.arbitraries.*
+
+class PositionTest extends DisciplineSuite {
+
+  checkAll("Position.OrderTests", OrderTests[Position].order)
+
+}


### PR DESCRIPTION
Add a check that a `end` position is always after the `start` position in a location. Also adds cats `Order` and [`Show`](https://typelevel.org/cats/typeclasses/show.html) instances and tests for their [laws](https://typelevel.org/cats/typeclasses/lawtesting.html)