### PR TITLE
feat!: use cats NonEmpty data structures for mutators and mutation levels

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -21,7 +21,9 @@ jobs:
       - run: git fetch --tags
       - uses: ./.github/setup
       - name: Compile code
-        run: sbt "compile; docs3/mdoc --check; mimaReportBinaryIssues"
+        # TODO: enable after releasing new major version
+        # run: sbt "compile; docs3/mdoc --check; mimaReportBinaryIssues"
+        run: sbt "compile; docs3/mdoc --check"
 
   formatting:
     runs-on: ubuntu-latest

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,5 +1,8 @@
+rules = [
+  OrganizeImports
+]
 OrganizeImports {
   coalesceToWildcardImportThreshold = 5
   groupedImports = Merge
+  targetDialect = Scala3
 }
-OrganizeImports.targetDialect = Scala3

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Mutate!
 import weaponregex.WeaponRegeX
 
 WeaponRegeX.mutate("^abc(d+|[xyz])$") match {
-    case Right(mutants) => mutants map (_.pattern)
+    case Right(mutants) => mutants.map(_.pattern)
     case Left(e)        => throw new RuntimeException(e)
 }
 // res0: Seq[String] = List(
@@ -74,7 +74,7 @@ import wrx from 'weapon-regex';
 let mutants = wrx.mutate('^abc(d+|[xyz])$');
 
 mutants.forEach((mutant) => {
-    console.log(mutant.pattern);
+  console.log(mutant.pattern);
 });
 ```
 
@@ -89,16 +89,17 @@ Note: as of 1.0.0 weapon-regex uses ES Modules.
 The `mutate` function has the following signature:
 
 ```scala
+import cats.data.{NonEmptyList, NonEmptySet}
 import weaponregex.model.mutation._
 import weaponregex.mutator.BuiltinMutators
 import weaponregex.parser.{ParserFlavor, ParserFlavorJVM}
 
 def mutate(
-              pattern       : String,
-              mutators      : Seq[TokenMutator] = BuiltinMutators.all,
-              mutationLevels: Seq[Int] = null,
-              flavor        : ParserFlavor = ParserFlavorJVM
-          ): Either[String, Seq[Mutant]] = ???
+    pattern       : String,
+    mutators      : NonEmptyList[TokenMutator] = BuiltinMutators.all,
+    mutationLevels: Option[NonEmptySet[Int]] = None,
+    flavor        : ParserFlavor = ParserFlavorJVM
+): Either[String, Seq[Mutant]] = ???
 ```
 
 With the `mutators` argument you can give a select list of mutators that should be used in
@@ -123,9 +124,9 @@ which parser flavor should be used in the mutation process:
 import wrx from 'weapon-regex';
 
 let mutants = wrx.mutate('^abc(d+|[xyz])$', 'u', {
-    mutators: Array.from(wrx.mutators.values()),
-    mutationLevels: [1, 2, 3],
-    flavor: wrx.ParserFlavorJS,
+  mutators: Array.from(wrx.mutators.values()),
+  mutationLevels: [1, 2, 3],
+  flavor: wrx.ParserFlavorJS,
 });
 ```
 
@@ -140,30 +141,30 @@ This function will return a JavaScript Array of `Mutant` if it can be parsed, or
 
 All the supported mutators and at which mutation level they appear are shown in the table below.
 
-| Name                                                            | 1 | 2 | 3 |
-|-----------------------------------------------------------------|---|---|---|
-| [BOLRemoval](#bolremoval)                                       | ✅ | ✅ | ✅ |
-| [EOLRemoval](#eolremoval)                                       | ✅ | ✅ | ✅ |
-| [BOL2BOI](#bol2boi)                                             |   | ✅ | ✅ |
-| [EOL2EOI](#eol2eoi)                                             |   | ✅ | ✅ |
-| [CharClassNegation](#charclassnegation)                         | ✅ |
-| [CharClassChildRemoval](#charclasschildremoval)                 |   | ✅ | ✅ |
-| [CharClassAnyChar](#charclassanychar)                           |   | ✅ | ✅ |
-| [CharClassRangeModification](#charclassrangemodification)       |   |   | ✅ |
-| [PredefCharClassNegation](#predefcharclassnegation)             | ✅ |
-| [PredefCharClassNullification](#predefcharclassnullification)   |   | ✅ | ✅ |
-| [PredefCharClassAnyChar](#predefcharclassanychar)               |   | ✅ | ✅ |
-| [UnicodeCharClassNegation](#unicodecharclassnegation)           | ✅ |
-| [QuantifierRemoval](#quantifierremoval)                         | ✅ |
-| [QuantifierNChange](#quantifiernchange)                         |   | ✅ | ✅ |
-| [QuantifierNOrMoreModification](#quantifiernormoremodification) |   | ✅ | ✅ |
-| [QuantifierNOrMoreChange](#quantifiernormorechange)             |   | ✅ | ✅ |
-| [QuantifierNMModification](#quantifiernmmodification)           |   | ✅ | ✅ |
-| [QuantifierShortModification](#quantifiershortmodification)     |   | ✅ | ✅ |
-| [QuantifierShortChange](#quantifiershortchange)                 |   | ✅ | ✅ |
-| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |   |   | ✅ |
-| [GroupToNCGroup](#grouptoncgroup)                               |   | ✅ | ✅ |
-| [LookaroundNegation](#lookaroundnegation)                       | ✅ | ✅ | ✅ |
+| Name                                                            | 1   | 2   | 3   |
+| --------------------------------------------------------------- | --- | --- | --- |
+| [BOLRemoval](#bolremoval)                                       | ✅  | ✅  | ✅  |
+| [EOLRemoval](#eolremoval)                                       | ✅  | ✅  | ✅  |
+| [BOL2BOI](#bol2boi)                                             |     | ✅  | ✅  |
+| [EOL2EOI](#eol2eoi)                                             |     | ✅  | ✅  |
+| [CharClassNegation](#charclassnegation)                         | ✅  |
+| [CharClassChildRemoval](#charclasschildremoval)                 |     | ✅  | ✅  |
+| [CharClassAnyChar](#charclassanychar)                           |     | ✅  | ✅  |
+| [CharClassRangeModification](#charclassrangemodification)       |     |     | ✅  |
+| [PredefCharClassNegation](#predefcharclassnegation)             | ✅  |
+| [PredefCharClassNullification](#predefcharclassnullification)   |     | ✅  | ✅  |
+| [PredefCharClassAnyChar](#predefcharclassanychar)               |     | ✅  | ✅  |
+| [UnicodeCharClassNegation](#unicodecharclassnegation)           | ✅  |
+| [QuantifierRemoval](#quantifierremoval)                         | ✅  |
+| [QuantifierNChange](#quantifiernchange)                         |     | ✅  | ✅  |
+| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     | ✅  | ✅  |
+| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     | ✅  | ✅  |
+| [QuantifierNMModification](#quantifiernmmodification)           |     | ✅  | ✅  |
+| [QuantifierShortModification](#quantifiershortmodification)     |     | ✅  | ✅  |
+| [QuantifierShortChange](#quantifiershortchange)                 |     | ✅  | ✅  |
+| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     | ✅  |
+| [GroupToNCGroup](#grouptoncgroup)                               |     | ✅  | ✅  |
+| [LookaroundNegation](#lookaroundnegation)                       | ✅  | ✅  | ✅  |
 
 ## Boundary Mutators
 
@@ -172,7 +173,7 @@ All the supported mutators and at which mutation level they appear are shown in 
 Remove the beginning of line character `^`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `^abc`   | `abc`   |
 
 [Back to table 🔝](#supported-mutators)
@@ -182,7 +183,7 @@ Remove the beginning of line character `^`.
 Remove the end of line character `$`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `abc$`   | `abc`   |
 
 [Back to table 🔝](#supported-mutators)
@@ -192,7 +193,7 @@ Remove the end of line character `$`.
 Change the beginning of line character `^` to a beginning of input character `\A`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `^abc`   | `\Aabc` |
 
 [Back to table 🔝](#supported-mutators)
@@ -202,7 +203,7 @@ Change the beginning of line character `^` to a beginning of input character `\A
 Change the end of line character `^` to a end of input character `\z`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `abc$`   | `abc\z` |
 
 [Back to table 🔝](#supported-mutators)
@@ -214,7 +215,7 @@ Change the end of line character `^` to a end of input character `\z`.
 Flips the sign of a character class.
 
 | Original | Mutated  |
-|----------|----------|
+| -------- | -------- |
 | `[abc]`  | `[^abc]` |
 | `[^abc]` | `[abc]`  |
 
@@ -225,7 +226,7 @@ Flips the sign of a character class.
 Remove a child of a character class.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `[abc]`  | `[bc]`  |
 | `[abc]`  | `[ac]`  |
 | `[abc]`  | `[ab]`  |
@@ -237,7 +238,7 @@ Remove a child of a character class.
 Change a character class to a character class which matches any character.
 
 | Original | Mutated  |
-|----------|----------|
+| -------- | -------- |
 | `[abc]`  | `[\w\W]` |
 
 [Back to table 🔝](#supported-mutators)
@@ -247,7 +248,7 @@ Change a character class to a character class which matches any character.
 Change the high and low of a range by one in both directions if possible.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `[b-y]`  | `[a-y]` |
 | `[b-y]`  | `[c-y]` |
 | `[b-y]`  | `[b-z]` |
@@ -262,7 +263,7 @@ Change the high and low of a range by one in both directions if possible.
 Flips the sign of a predefined character class. All the predefined character classes are shown in the table below.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `\d`     | `\D`    |
 | `\D`     | `\d`    |
 | `\s`     | `\S`    |
@@ -277,7 +278,7 @@ Flips the sign of a predefined character class. All the predefined character cla
 Remove the backslash from a predefined character class such as `\w`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `\d`     | `d`     |
 | `\D`     | `D`     |
 | `\s`     | `s`     |
@@ -293,7 +294,7 @@ Change a predefined character class to a character class containing the predefin
 negation.
 
 | Original | Mutated  |
-|----------|----------|
+| -------- | -------- |
 | `\d`     | `[\d\D]` |
 | `\D`     | `[\D\d]` |
 | `\s`     | `[\s\S]` |
@@ -308,7 +309,7 @@ negation.
 Flips the sign of a Unicode character class.
 
 | Original    | Mutated     |
-|-------------|-------------|
+| ----------- | ----------- |
 | `\p{Alpha}` | `\P{Alpha}` |
 | `\P{Alpha}` | `\p{Alpha}` |
 
@@ -322,7 +323,7 @@ Remove a quantifier. This is done for all possible quantifiers, even ranges, and
 and possessive variants.
 
 | Original    | Mutated |
-|-------------|---------|
+| ----------- | ------- |
 | `abc?`      | `abc`   |
 | `abc*`      | `abc`   |
 | `abc+`      | `abc`   |
@@ -343,7 +344,7 @@ and possessive variants.
 Change the fixed amount quantifier to a couple of range variants.
 
 | Original | Mutated    |
-|----------|------------|
+| -------- | ---------- |
 | `abc{9}` | `abc{0,9}` |
 | `abc{9}` | `abc{9,}`  |
 
@@ -355,7 +356,7 @@ Change the `n` to infinity range quantifier to a couple of variants where the lo
 incremented and decremented by one.
 
 | Original  | Mutated    |
-|-----------|------------|
+| --------- | ---------- |
 | `abc{9,}` | `abc{8,}`  |
 | `abc{9,}` | `abc{10,}` |
 
@@ -366,7 +367,7 @@ incremented and decremented by one.
 Turn an `n` or more range quantifier into a fixed number quantifier.
 
 | Original  | Mutated  |
-|-----------|----------|
+| --------- | -------- |
 | `abc{9,}` | `abc{9}` |
 
 [Back to table 🔝](#supported-mutators)
@@ -377,7 +378,7 @@ Alter the `n` to `m` range quantifier by decrementing or incrementing the high a
 range by one.
 
 | Original   | Mutated     |
-|------------|-------------|
+| ---------- | ----------- |
 | `abc{3,9}` | `abc{2,9}`  |
 | `abc{3,9}` | `abc{4,9}`  |
 | `abc{3,9}` | `abc{3,8}`  |
@@ -392,7 +393,7 @@ variant (`{0,1}`, `{0,}`, `{1,}`), and applies the same mutations as mentioned i
 above.
 
 | Original | Mutated    |
-|----------|------------|
+| -------- | ---------- |
 | `abc?`   | `abc{1,1}` |
 | `abc?`   | `abc{0,0}` |
 | `abc?`   | `abc{0,2}` |
@@ -407,7 +408,7 @@ above.
 Change the shorthand quantifiers `*` and `+` to their fixed range quantifier variant.
 
 | Original | Mutated  |
-|----------|----------|
+| -------- | -------- |
 | `abc*`   | `abc{0}` |
 | `abc+`   | `abc{1}` |
 
@@ -418,7 +419,7 @@ Change the shorthand quantifiers `*` and `+` to their fixed range quantifier var
 Change greedy quantifiers to reluctant quantifiers.
 
 | Original    | Mutated      |
-|-------------|--------------|
+| ----------- | ------------ |
 | `abc?`      | `abc??`      |
 | `abc*`      | `abc*?`      |
 | `abc+`      | `abc+?`      |
@@ -435,7 +436,7 @@ Change greedy quantifiers to reluctant quantifiers.
 Change a normal group to a non-capturing group.
 
 | Original | Mutated   |
-|----------|-----------|
+| -------- | --------- |
 | `(abc)`  | `(?:abc)` |
 
 [Back to table 🔝](#supported-mutators)
@@ -445,7 +446,7 @@ Change a normal group to a non-capturing group.
 Flips the sign of a lookaround (lookahead, lookbehind) construct.
 
 | Original   | Mutated    |
-|------------|------------|
+| ---------- | ---------- |
 | `(?=abc)`  | `(?!abc)`  |
 | `(?!abc)`  | `(?=abc)`  |
 | `(?<=abc)` | `(?<!abc)` |

--- a/core/src/main/scala/weaponregex/WeaponRegeX.scala
+++ b/core/src/main/scala/weaponregex/WeaponRegeX.scala
@@ -1,5 +1,6 @@
 package weaponregex
 
+import cats.data.{NonEmptyList, NonEmptySet}
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.internal.parser.Parser
 import weaponregex.model.mutation.{Mutant, TokenMutator}
@@ -16,15 +17,15 @@ object WeaponRegeX {
     * @param mutators
     *   Mutators to be used for mutation
     * @param mutationLevels
-    *   Target mutation levels. If this is `null`, the `mutators` will not be filtered.
+    *   Target mutation levels. If this is `None`, the `mutators` will not be filtered.
     * @return
     *   A `Right` of a sequence of [[weaponregex.model.mutation.Mutant]] if can be parsed, a `Left` with the error
     *   message otherwise
     */
   def mutate(
       pattern: String,
-      mutators: Seq[TokenMutator] = BuiltinMutators.all,
-      mutationLevels: Seq[Int] = null,
+      mutators: NonEmptyList[TokenMutator] = BuiltinMutators.all,
+      mutationLevels: Option[NonEmptySet[Int]] = None,
       flavor: ParserFlavor = ParserFlavorJVM
   ): Either[String, Seq[Mutant]] = Parser(pattern, flavor) map (_.mutate(mutators, mutationLevels))
 }

--- a/core/src/main/scala/weaponregex/internal/extension/RegexTreeExtension.scala
+++ b/core/src/main/scala/weaponregex/internal/extension/RegexTreeExtension.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.extension
 
+import cats.data.{NonEmptyList, NonEmptySet}
 import weaponregex.internal.extension.TokenMutatorExtension.TokenMutatorsFiltering
 import weaponregex.internal.model.regextree.*
 import weaponregex.model.mutation.{Mutant, TokenMutator}
@@ -60,22 +61,27 @@ private[weaponregex] object RegexTreeExtension {
       * @param mutators
       *   Mutators to be used for mutation
       * @param mutationLevels
-      *   Target mutation levels. If this is `null`, the `mutators` will not be filtered.
+      *   Target mutation levels. If this is `None`, the `mutators` will not be filtered.
       * @return
       *   A sequence of [[weaponregex.model.mutation.Mutant]]
       */
-    def mutate(mutators: Seq[TokenMutator] = BuiltinMutators.all, mutationLevels: Seq[Int] = null): Seq[Mutant] = {
-      if (mutationLevels != null) return mutate(mutators.atLevels(mutationLevels))
-
-      val rootMutants: Seq[Mutant] = mutators.flatMap(_.mutate(tree))
-      val childrenMutants: Seq[Mutant] = tree match {
-        case node: Node =>
-          node.children.flatMap { child =>
-            child.mutate(mutators).map(mutant => mutant.copy(pattern = tree.buildWith(child, mutant.pattern)))
+    def mutate(
+        mutators: NonEmptyList[TokenMutator] = BuiltinMutators.all,
+        mutationLevels: Option[NonEmptySet[Int]] = None
+    ): Seq[Mutant] = {
+      mutationLevels match {
+        case Some(levels) => mutators.atLevels(levels).map(mutate(_)).getOrElse(Nil)
+        case None         =>
+          val rootMutants: Seq[Mutant] = mutators.toList.flatMap(_.mutate(tree))
+          val childrenMutants: Seq[Mutant] = tree match {
+            case node: Node =>
+              node.children.flatMap { child =>
+                child.mutate(mutators).map(mutant => mutant.copy(pattern = tree.buildWith(child, mutant.pattern)))
+              }
+            case _ => Seq.empty
           }
-        case _ => Seq.empty
+          rootMutants ++ childrenMutants
       }
-      rootMutants ++ childrenMutants
     }
   }
 }

--- a/core/src/main/scala/weaponregex/internal/extension/TokenMutatorExtension.scala
+++ b/core/src/main/scala/weaponregex/internal/extension/TokenMutatorExtension.scala
@@ -1,12 +1,14 @@
 package weaponregex.internal.extension
 
+import cats.data.{NonEmptyList, NonEmptySet}
+import cats.syntax.all.*
 import weaponregex.model.mutation.TokenMutator
 
 private[weaponregex] object TokenMutatorExtension {
 
   /** The extension that filter a given sequence of [[weaponregex.model.mutation.TokenMutator]]
     */
-  implicit class TokenMutatorsFiltering(val mutators: Seq[TokenMutator]) extends AnyVal {
+  implicit class TokenMutatorsFiltering(val mutators: NonEmptyList[TokenMutator]) extends AnyVal {
 
     /** Filter token mutators based on the given mutation level
       * @param mutationLevel
@@ -14,8 +16,8 @@ private[weaponregex] object TokenMutatorExtension {
       * @return
       *   Sequence of token mutators in the given mutation levels
       */
-    def atLevel(mutationLevel: Int): Seq[TokenMutator] =
-      mutators filter (_.levels.contains(mutationLevel))
+    def atLevel(mutationLevel: Int): Option[NonEmptyList[TokenMutator]] =
+      mutators.filter(_.levels.contains(mutationLevel)).toNel
 
     /** Filter token mutators based on the given mutation levels
       * @param mutationLevels
@@ -23,7 +25,7 @@ private[weaponregex] object TokenMutatorExtension {
       * @return
       *   Sequence of token mutators in the given mutation levels
       */
-    def atLevels(mutationLevels: Seq[Int]): Seq[TokenMutator] =
-      mutators filter (mutator => mutationLevels exists (mutator.levels contains _))
+    def atLevels(mutationLevels: NonEmptySet[Int]): Option[NonEmptyList[TokenMutator]] =
+      mutators.filter(mutator => mutationLevels.exists(mutator.levels.contains(_))).toNel
   }
 }

--- a/core/src/main/scala/weaponregex/internal/model/regextree/logicalNode.scala
+++ b/core/src/main/scala/weaponregex/internal/model/regextree/logicalNode.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.model.regextree
 
+import cats.data.NonEmptyList
 import weaponregex.model.Location
 
 /** Concatenation node
@@ -9,7 +10,7 @@ import weaponregex.model.Location
   * @param location
   *   The [[weaponregex.model.Location]] of the node in the regex string
   */
-case class Concat(nodes: Seq[RegexTree], override val location: Location) extends Node(nodes, location)
+case class Concat(nodes: NonEmptyList[RegexTree], override val location: Location) extends Node(nodes.toList, location)
 
 /** Or node (e.g. `a|b|c`)
   * @param nodes
@@ -17,4 +18,5 @@ case class Concat(nodes: Seq[RegexTree], override val location: Location) extend
   * @param location
   *   The [[weaponregex.model.Location]] of the node in the regex string
   */
-case class Or(nodes: Seq[RegexTree], override val location: Location) extends Node(nodes, location, sep = "|")
+case class Or(nodes: NonEmptyList[RegexTree], override val location: Location)
+    extends Node(nodes.toList, location, sep = "|")

--- a/core/src/main/scala/weaponregex/internal/mutator/boundaryMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/boundaryMutator.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptySet
 import weaponregex.internal.TokenMutator
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.model.regextree.*
@@ -14,7 +15,7 @@ import weaponregex.model.mutation.Mutant
   */
 object BOLRemoval extends TokenMutator {
   override val name: String = "Beginning of line character `^` removal"
-  override val levels: Seq[Int] = Seq(1, 2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(1, 2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     location.show + " Remove the beginning of line character `^`"
 
@@ -36,7 +37,7 @@ object BOLRemoval extends TokenMutator {
   */
 object EOLRemoval extends TokenMutator {
   override val name: String = "End of line character `$` removal"
-  override val levels: Seq[Int] = Seq(1, 2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(1, 2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     location.show + " Remove the end of line character `$`"
 
@@ -58,7 +59,7 @@ object EOLRemoval extends TokenMutator {
   */
 object BOL2BOI extends TokenMutator {
   override val name: String = """Beginning of line `^` to beginning of input `\A` change"""
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     location.show + """ Change the beginning of line `^` to beginning of input `\A`"""
 
@@ -76,7 +77,7 @@ object BOL2BOI extends TokenMutator {
   */
 object EOL2EOI extends TokenMutator {
   override val name: String = """End of line `$` to end of input `\z` change"""
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     location.show + """ Change the end of line `$` to end of input `\z`"""
 

--- a/core/src/main/scala/weaponregex/internal/mutator/capturingMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/capturingMutator.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptySet
 import weaponregex.internal.TokenMutator
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.model.regextree.*
@@ -14,7 +15,7 @@ import weaponregex.model.mutation.Mutant
   */
 object GroupToNCGroup extends TokenMutator {
   override val name: String = "Capturing group to non-capturing group modification"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Modify the capturing group `$original` to non-capturing group `$mutated`"
 
@@ -32,7 +33,7 @@ object GroupToNCGroup extends TokenMutator {
   */
 object LookaroundNegation extends TokenMutator {
   override val name: String = "Lookaround constructs (lookahead, lookbehind) negation"
-  override val levels: Seq[Int] = Seq(1, 2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(1, 2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Negate the lookaround construct `$original` to `$mutated`"
 

--- a/core/src/main/scala/weaponregex/internal/mutator/charClassMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/charClassMutator.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptySet
 import weaponregex.internal.TokenMutator
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.model.regextree.*
@@ -14,7 +15,7 @@ import weaponregex.model.mutation.Mutant
   */
 object CharClassNegation extends TokenMutator {
   override val name = "Character class negation"
-  override val levels: Seq[Int] = Seq(1)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(1)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Negate the character class `$original` to `$mutated`"
 
@@ -32,7 +33,7 @@ object CharClassNegation extends TokenMutator {
   */
 object CharClassChildRemoval extends TokenMutator {
   override val name: String = "Character class child removal"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
 
   override def mutate(token: RegexTree): Seq[Mutant] = {
     def _mutate(token: Node): Seq[Mutant] = token.children map (child =>
@@ -63,7 +64,7 @@ object CharClassChildRemoval extends TokenMutator {
   */
 object CharClassAnyChar extends TokenMutator {
   override val name = """Character class to `[\w\W]` change"""
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Change the character class `$original` to match any character `[\\w\\W]`"
 
@@ -84,7 +85,7 @@ object CharClassAnyChar extends TokenMutator {
   */
 object CharClassRangeModification extends TokenMutator {
   override val name = "Character class range modification"
-  override val levels: Seq[Int] = Seq(3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(3)
 
   // [b-y] -> [a-y] or [c-y] or [b-z] or [b-x]
   // [a-y] -> [b-y] or [a-z] or [a-x]

--- a/core/src/main/scala/weaponregex/internal/mutator/predefCharClassMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/predefCharClassMutator.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptySet
 import weaponregex.internal.TokenMutator
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.extension.StringExtension.*
@@ -15,7 +16,7 @@ import weaponregex.model.mutation.Mutant
   */
 object PredefCharClassNegation extends TokenMutator {
   override val name = "Predefined character class negation"
-  override val levels: Seq[Int] = Seq(1)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(1)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Negate the predefined character class `$original` to `$mutated`"
 
@@ -33,7 +34,7 @@ object PredefCharClassNegation extends TokenMutator {
   */
 object PredefCharClassNullification extends TokenMutator {
   override val name = "Predefined character class nullification"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Nullify the predefined character class `$original` by removing the `\\`"
 
@@ -51,7 +52,7 @@ object PredefCharClassNullification extends TokenMutator {
   */
 object PredefCharClassAnyChar extends TokenMutator {
   override val name = "Predefined character class to character class with its negation change"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Change the predefined character class `$original` to a character class with its negation `$mutated` to match any character"
 
@@ -70,7 +71,7 @@ object PredefCharClassAnyChar extends TokenMutator {
   */
 object UnicodeCharClassNegation extends TokenMutator {
   override val name = "Unicode character class negation"
-  override val levels: Seq[Int] = Seq(1)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(1)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} sNegate Unicode character class `$original` to `$mutated`"
 

--- a/core/src/main/scala/weaponregex/internal/mutator/quantifierMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/quantifierMutator.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptySet
 import weaponregex.internal.TokenMutator
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.model.regextree.*
@@ -14,7 +15,7 @@ import weaponregex.model.mutation.Mutant
   */
 object QuantifierRemoval extends TokenMutator {
   override val name: String = "Quantifier removal"
-  override val levels: Seq[Int] = Seq(1)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(1)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Remove the quantifier from `$original` to `$mutated`"
 
@@ -35,7 +36,7 @@ object QuantifierRemoval extends TokenMutator {
   */
 object QuantifierNChange extends TokenMutator {
   override val name: String = "Quantifier `{n}` to `{0,n}` and `{n,}` change"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Change the quantifier from `$original` to `$mutated`"
 
@@ -57,7 +58,7 @@ object QuantifierNChange extends TokenMutator {
   */
 object QuantifierNOrMoreModification extends TokenMutator {
   override val name: String = "Quantifier `{n,}` to `{n-1,}` and `{n+1,}` modification"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Modify the quantifier from `$original` to `$mutated`"
 
@@ -77,7 +78,7 @@ object QuantifierNOrMoreModification extends TokenMutator {
   */
 object QuantifierNOrMoreChange extends TokenMutator {
   override val name: String = "Quantifier `{n,}` to `{n}` change"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Change the quantifier from `$original` to `$mutated`"
 
@@ -95,7 +96,7 @@ object QuantifierNOrMoreChange extends TokenMutator {
   */
 object QuantifierNMModification extends TokenMutator {
   override val name: String = "Quantifier `{n,m}` modification"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Change the quantifier from `$original` to `$mutated`"
 
@@ -130,7 +131,7 @@ object QuantifierNMModification extends TokenMutator {
   */
 object QuantifierShortModification extends TokenMutator {
   override val name: String = "Short quantifier to `{n,}` or `{n,m}` modification"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Change the short quantifier from `$original` to `$mutated`"
 
@@ -160,7 +161,7 @@ object QuantifierShortModification extends TokenMutator {
   */
 object QuantifierShortChange extends TokenMutator {
   override val name: String = "Short quantifier `*` and `+` to `{n}` change"
-  override val levels: Seq[Int] = Seq(2, 3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(2, 3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Change the short quantifier from `$original` to `$mutated`"
 
@@ -181,7 +182,7 @@ object QuantifierShortChange extends TokenMutator {
   */
 object QuantifierReluctantAddition extends TokenMutator {
   override val name: String = "Greedy quantifier to reluctant quantifier modification"
-  override val levels: Seq[Int] = Seq(3)
+  override val levels: NonEmptySet[Int] = NonEmptySet.of(3)
   override def description(original: String, mutated: String, location: Location): String =
     s"${location.show} Modify the greedy quantifier `$original` to reluctant quantifier `$mutated`"
 

--- a/core/src/main/scala/weaponregex/internal/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/Parser.scala
@@ -702,7 +702,7 @@ abstract private[weaponregex] class Parser {
     */
   protected val concat: P[Concat] =
     indexed(basicRE.rep(min = 2))
-      .map { case (loc, nodes) => Concat(nodes.toList, loc) }
+      .map { case (loc, nodes) => Concat(nodes, loc) }
       .withContext("concatenation")
 
   /** Parse an empty string
@@ -731,7 +731,7 @@ abstract private[weaponregex] class Parser {
   protected val or: P[Or] =
     indexed(
       (simpleRE | empty).with1 ~ (P.char('|') *> (simpleRE | empty)).rep
-    ).map { case (loc, (first, rest)) => Or(first :: rest.toList, loc) }
+    ).map { case (loc, (first, rest)) => Or(first :: rest, loc) }
       .withContext("or")
 
   /** The top-level parsing rule which can parse either `or` or `simpleRE`

--- a/core/src/main/scala/weaponregex/model/mutation/Mutant.scala
+++ b/core/src/main/scala/weaponregex/model/mutation/Mutant.scala
@@ -1,5 +1,6 @@
 package weaponregex.model.mutation
 
+import cats.data.NonEmptySet
 import weaponregex.model.Location
 
 /** A mutation made by the mutator.
@@ -20,7 +21,7 @@ case class Mutant(
     pattern: String,
     name: String,
     location: Location,
-    levels: Seq[Int],
+    levels: NonEmptySet[Int],
     description: String,
     replacement: String
 )

--- a/core/src/main/scala/weaponregex/model/mutation/TokenMutator.scala
+++ b/core/src/main/scala/weaponregex/model/mutation/TokenMutator.scala
@@ -1,5 +1,6 @@
 package weaponregex.model.mutation
 
+import cats.data.NonEmptySet
 import weaponregex.internal.model.regextree.RegexTree
 import weaponregex.model.Location
 
@@ -11,7 +12,7 @@ trait TokenMutator {
 
   /** The mutation levels that the token mutator falls under
     */
-  val levels: Seq[Int]
+  val levels: NonEmptySet[Int]
 
   /** Generate the default description for the mutants of this mutator
     * @param original

--- a/core/src/main/scala/weaponregex/mutator/BuiltinMutators.scala
+++ b/core/src/main/scala/weaponregex/mutator/BuiltinMutators.scala
@@ -1,5 +1,7 @@
 package weaponregex.mutator
 
+import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet}
+import cats.syntax.all.*
 import weaponregex.internal.mutator.*
 import weaponregex.model.mutation.TokenMutator
 
@@ -9,7 +11,7 @@ object BuiltinMutators {
 
   /** Sequence of all built-in token mutators
     */
-  val all: Seq[TokenMutator] = Seq(
+  val all: NonEmptyList[TokenMutator] = NonEmptyList.of(
     BOLRemoval,
     EOLRemoval,
     BOL2BOI,
@@ -36,21 +38,19 @@ object BuiltinMutators {
 
   /** Map from mutator class name to the associating token mutator
     */
-  lazy val byName: Map[String, TokenMutator] =
-    (all map (mutator => mutator.getClass.getSimpleName.stripSuffix("$") -> mutator)).toMap
+  lazy val byName: NonEmptyMap[String, TokenMutator] =
+    all.map(mutator => mutator.getClass.getSimpleName.stripSuffix("$") -> mutator).toNem
 
   /** Map from mutation level number to token mutators in that level
     */
-  lazy val byLevel: Map[Int, Seq[TokenMutator]] =
-    all.foldLeft(Map.empty[Int, Seq[TokenMutator]])((levels, mutator) =>
-      mutator.levels.foldLeft(levels)((ls, level) => ls + (level -> (ls.getOrElse(level, Nil) :+ mutator)))
-    )
+  lazy val byLevel: NonEmptyMap[Int, NonEmptyList[TokenMutator]] =
+    all.flatMap(m => m.levels.toNonEmptyList.map(_ -> m)).groupMapNem { case (l, _) => l } { case (_, m) => m }
 
-  final def apply(className: String): TokenMutator = byName.getOrElse(className, null)
+  final def apply(className: String): Option[TokenMutator] = byName(className)
 
-  final def apply(mutationLevel: Int): Seq[TokenMutator] = atLevel(mutationLevel)
+  final def apply(mutationLevel: Int): Option[NonEmptyList[TokenMutator]] = atLevel(mutationLevel)
 
-  final def apply(mutationLevels: Seq[Int]): Seq[TokenMutator] = atLevels(mutationLevels)
+  final def apply(mutationLevels: NonEmptySet[Int]): Option[NonEmptyList[TokenMutator]] = atLevels(mutationLevels)
 
   /** Get all the token mutators in the given mutation level
     * @param mutationLevel
@@ -58,7 +58,7 @@ object BuiltinMutators {
     * @return
     *   Sequence of all the tokens mutators in that level, if any
     */
-  def atLevel(mutationLevel: Int): Seq[TokenMutator] = byLevel.getOrElse(mutationLevel, Nil)
+  def atLevel(mutationLevel: Int): Option[NonEmptyList[TokenMutator]] = byLevel(mutationLevel)
 
   /** Get all the token mutators in the given mutation levels
     * @param mutationLevels
@@ -66,5 +66,6 @@ object BuiltinMutators {
     * @return
     *   Sequence of all the tokens mutators in that levels, if any
     */
-  def atLevels(mutationLevels: Seq[Int]): Seq[TokenMutator] = mutationLevels flatMap atLevel
+  def atLevels(mutationLevels: NonEmptySet[Int]): Option[NonEmptyList[TokenMutator]] =
+    mutationLevels.toNonEmptyList.map(atLevel).combineAll
 }

--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -36,7 +36,7 @@ object WeaponRegeXJS {
     */
   @JSExportTopLevel("mutate")
   def mutate(pattern: String, flags: js.UndefOr[String], options: js.UndefOr[MutationOptions]): js.Array[MutantJS] = {
-    val (mutators, mutationLevels, flavor) = options.getOrElse(new MutationOptions).toScala
+    val (mutators, mutationLevels, flavor) = options.toOption.flatMap(Option(_)).getOrElse(new MutationOptions).toScala
     val flagsOpt = flags.toOption.filterNot(_ == null).filterNot(_.isEmpty)
 
     Parser(pattern, flagsOpt, flavor) match {

--- a/core/src/main/scalajs/weaponregex/internal/extension/MutationOptionsExtension.scala
+++ b/core/src/main/scalajs/weaponregex/internal/extension/MutationOptionsExtension.scala
@@ -1,5 +1,7 @@
 package weaponregex.internal.extension
 
+import cats.data.{NonEmptyList, NonEmptySet}
+import cats.syntax.all.*
 import weaponregex.model.MutationOptions
 import weaponregex.model.mutation.TokenMutator
 import weaponregex.mutator.BuiltinMutators
@@ -15,16 +17,16 @@ private[weaponregex] object MutationOptionsExtension {
       * @return
       *   A tuple of (mutators, mutationLevels, flavor)
       */
-    def toScala: (Seq[TokenMutator], Seq[Int], ParserFlavor) = {
-      val mutators: Seq[TokenMutator] =
+    def toScala: (NonEmptyList[TokenMutator], Option[NonEmptySet[Int]], ParserFlavor) = {
+      val mutators: NonEmptyList[TokenMutator] =
         if (mutationOptions.hasOwnProperty("mutators") && mutationOptions.mutators != null)
-          mutationOptions.mutators.toSeq map (_.tokenMutator)
+          mutationOptions.mutators.toList.map(_.tokenMutator).toNel.getOrElse(BuiltinMutators.all)
         else BuiltinMutators.all
 
-      val mutationLevels: Seq[Int] =
+      val mutationLevels: Option[NonEmptySet[Int]] =
         if (mutationOptions.hasOwnProperty("mutationLevels") && mutationOptions.mutationLevels != null)
-          mutationOptions.mutationLevels.toSeq
-        else null
+          mutationOptions.mutationLevels.toList.toNel.map(_.toNes)
+        else None
 
       val flavor: ParserFlavor =
         if (mutationOptions.hasOwnProperty("flavor") && mutationOptions.flavor != null)

--- a/core/src/main/scalajs/weaponregex/model/mutation/MutantJS.scala
+++ b/core/src/main/scalajs/weaponregex/model/mutation/MutantJS.scala
@@ -29,7 +29,7 @@ case class MutantJS(mutant: Mutant) {
 
   /** The mutation levels of the mutator
     */
-  val levels: js.Array[Int] = mutant.levels.toJSArray
+  val levels: js.Array[Int] = mutant.levels.toSortedSet.toJSArray
 
   /** Description on the mutation
     */

--- a/core/src/main/scalajs/weaponregex/model/mutation/TokenMutatorJS.scala
+++ b/core/src/main/scalajs/weaponregex/model/mutation/TokenMutatorJS.scala
@@ -22,7 +22,7 @@ case class TokenMutatorJS(tokenMutator: TokenMutator) {
   /** The mutation levels that the token mutator falls under
     */
   @JSExport
-  val levels: js.Array[Int] = tokenMutator.levels.toJSArray
+  val levels: js.Array[Int] = tokenMutator.levels.toSortedSet.toJSArray
 
   /** Mutate the given token
     * @param token

--- a/core/src/main/scalajs/weaponregex/mutator/BuiltinMutatorsJS.scala
+++ b/core/src/main/scalajs/weaponregex/mutator/BuiltinMutatorsJS.scala
@@ -1,5 +1,7 @@
 package weaponregex.mutator
 
+import cats.data.NonEmptyList
+import cats.syntax.all.*
 import weaponregex.model.mutation.{TokenMutator, TokenMutatorJS}
 
 import scala.scalajs.js
@@ -19,23 +21,23 @@ object BuiltinMutatorsJS {
     * @return
     *   A JS array of [[weaponregex.model.mutation.TokenMutatorJS]]
     */
-  private def toTokenMutatorJSArray(mutators: Seq[TokenMutator]): js.Array[TokenMutatorJS] =
-    mutators.map(TokenMutatorJS(_)).toJSArray
+  private def toTokenMutatorJSArray(mutators: Option[NonEmptyList[TokenMutator]]): js.Array[TokenMutatorJS] =
+    mutators.map(_.toList.map(TokenMutatorJS(_))).orEmpty.toJSArray
 
   /** JS Array of all built-in token mutators
     */
-  val all: js.Array[TokenMutatorJS] = toTokenMutatorJSArray(BuiltinMutators.all)
+  val all: js.Array[TokenMutatorJS] = toTokenMutatorJSArray(BuiltinMutators.all.some)
 
   /** JS Map that maps from a token mutator class names to the associating token mutator
     */
   @JSExportTopLevel("mutators")
   val byName: js.Map[String, TokenMutatorJS] =
-    (BuiltinMutators.byName transform ((_, mutator) => TokenMutatorJS(mutator))).toJSMap
+    BuiltinMutators.byName.transform((_, mutator) => TokenMutatorJS(mutator)).toSortedMap.toJSMap
 
   /** JS Map that maps from mutation level number to token mutators in that level
     */
   lazy val byLevel: js.Map[Int, js.Array[TokenMutatorJS]] =
-    (BuiltinMutators.byLevel transform ((_, mutators) => toTokenMutatorJSArray(mutators))).toJSMap
+    BuiltinMutators.byLevel.transform((_, mutators) => toTokenMutatorJSArray(mutators.some)).toSortedMap.toJSMap
 
   /** Get all the token mutators in the given mutation level
     * @param mutationLevel
@@ -53,5 +55,7 @@ object BuiltinMutatorsJS {
     *   Array of all the tokens mutators in that levels, if any
     */
   def atLevels(mutationLevels: js.Array[Int]): js.Array[TokenMutatorJS] =
-    toTokenMutatorJSArray(BuiltinMutators.atLevels(mutationLevels.toSeq))
+    mutationLevels.toList.toNel
+      .fold(js.Array[TokenMutatorJS]())(levels => toTokenMutatorJSArray(BuiltinMutators.atLevels(levels.toNes)))
+
 }

--- a/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
+++ b/core/src/test/scala/weaponregex/WeaponRegeXTest.scala
@@ -1,5 +1,7 @@
 package weaponregex
 
+import cats.data.NonEmptySet
+import cats.syntax.all.*
 import weaponregex.internal.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.model.mutation.Mutant
 import weaponregex.mutator.BuiltinMutators
@@ -19,29 +21,22 @@ class WeaponRegeXTest extends munit.FunSuite {
     assertEquals(mutations.length, 2)
   }
 
-  test("Can mutate with empty sequence of mutators as option") {
-    val mutations = WeaponRegeX.mutate("^a", Nil).getOrFail
-
-    assert(mutations.isInstanceOf[Seq[Mutant]])
-    assertEquals(mutations, Nil)
-  }
-
   test("Can mutate with only levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(1)).getOrFail
+    val mutations = WeaponRegeX.mutate("^a", mutationLevels = NonEmptySet.of(1).some).getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 1)
   }
 
   test("Can mutate with unsupported levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", mutationLevels = Seq(100, 1000)).getOrFail
+    val mutations = WeaponRegeX.mutate("^a", mutationLevels = NonEmptySet.of(100, 1000).some).getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations, Nil)
   }
 
   test("Can mutate with both mutators and levels as option") {
-    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all, Seq(1)).getOrFail
+    val mutations = WeaponRegeX.mutate("^a", BuiltinMutators.all, NonEmptySet.of(1).some).getOrFail
 
     assert(mutations.isInstanceOf[Seq[Mutant]])
     assertEquals(mutations.length, 1)

--- a/core/src/test/scala/weaponregex/internal/extension/TokenMutatorExtensionTest.scala
+++ b/core/src/test/scala/weaponregex/internal/extension/TokenMutatorExtensionTest.scala
@@ -1,40 +1,42 @@
 package weaponregex.internal.extension
 
+import cats.data.NonEmptySet
+import cats.syntax.all.*
 import weaponregex.internal.extension.TokenMutatorExtension.TokenMutatorsFiltering
 import weaponregex.mutator.BuiltinMutators
 
 class TokenMutatorExtensionTest extends munit.FunSuite {
   test("Filter a single level") {
     val level = 1
-    val mutators = BuiltinMutators.all.atLevel(level)
-    mutators foreach (mutator => assert(clue(mutator).levels contains level))
+    val mutators = BuiltinMutators.all.atLevel(level).get
+    mutators.toList.foreach(mutator => assert(clue(mutator).levels.contains(level)))
   }
 
   test("Filter a single non-existed level") {
     val level = -1
     val mutators = BuiltinMutators.all.atLevel(level)
-    assert(clue(mutators) == Nil)
+    assertEquals(mutators, None)
   }
 
   test("Filter multiple levels") {
-    val levels = Seq(1, 2, 3)
-    val mutators = BuiltinMutators.all.atLevels(levels)
-    mutators foreach (mutator => assert(levels exists (clue(mutator).levels contains _)))
+    val levels = NonEmptySet.of(1, 2, 3)
+    val mutators = BuiltinMutators.all.atLevels(levels).get
+    mutators.toList.foreach(mutator => assert(levels.exists(clue(mutator).levels.contains(_))))
   }
 
   test("Filter multiple levels with some non-existed levels") {
-    val levels = Seq(1, 2, 3)
-    val badLevels = Seq(-1, -2, -3)
-    val mutators = BuiltinMutators.all.atLevels(levels ++ badLevels)
-    mutators foreach (mutator => {
-      assert(levels exists (clue(mutator).levels contains _))
-      assert(!(badLevels exists (clue(mutator).levels contains _)))
+    val levels = NonEmptySet.of(1, 2, 3)
+    val badLevels = NonEmptySet.of(-1, -2, -3)
+    val mutators = BuiltinMutators.all.atLevels(levels ++ badLevels).get
+    mutators.toList.foreach(mutator => {
+      assert(levels.exists(clue(mutator).levels.contains(_)))
+      assert(!badLevels.exists(clue(mutator).levels.contains(_)))
     })
   }
 
   test("Filter non-existed multiple levels") {
-    val levels = Seq(-1, -2, -3)
+    val levels = NonEmptySet.of(-1, -2, -3)
     val mutators = BuiltinMutators.all.atLevels(levels)
-    assert(clue(mutators) == Nil)
+    assertEquals(mutators, None)
   }
 }

--- a/core/src/test/scala/weaponregex/internal/model/regextree/LogicalNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/LogicalNodeTest.scala
@@ -1,22 +1,23 @@
 package weaponregex.internal.model.regextree
 
+import cats.data.NonEmptyList
 import weaponregex.internal.constant.RegexTreeStubs.*
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class LogicalNodeTest extends munit.FunSuite {
   test("Concat build") {
-    val node1 = Concat(Seq(LEAF_A, LEAF_B), LOCATION)
+    val node1 = Concat(NonEmptyList.of(LEAF_A, LEAF_B), LOCATION)
     assertEquals(node1.build, "AB")
 
-    val node2 = Concat(Seq(LEAF_A, LEAF_B, LEAF_C), LOCATION)
+    val node2 = Concat(NonEmptyList.of(LEAF_A, LEAF_B, LEAF_C), LOCATION)
     assertEquals(node2.build, "ABC")
   }
 
   test("Or build") {
-    val node1 = Or(Seq(LEAF_A, LEAF_B), LOCATION)
+    val node1 = Or(NonEmptyList.of(LEAF_A, LEAF_B), LOCATION)
     assertEquals(node1.build, "A|B")
 
-    val node2 = Or(Seq(LEAF_A, LEAF_B, LEAF_C), LOCATION)
+    val node2 = Or(NonEmptyList.of(LEAF_A, LEAF_B, LEAF_C), LOCATION)
     assertEquals(node2.build, "A|B|C")
   }
 }

--- a/core/src/test/scala/weaponregex/internal/model/regextree/RegexTreeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/RegexTreeTest.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.model.regextree
 
+import cats.data.NonEmptyList
 import weaponregex.internal.constant.RegexTreeStubs.LOCATION
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
@@ -8,7 +9,7 @@ class RegexTreeTest extends munit.FunSuite {
     val pattern: String = """^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$"""
     val loc = LOCATION
     val tree: RegexTree = Concat(
-      Seq(
+      NonEmptyList.of(
         BOL(loc),
         OneOrMore(
           PredefinedCharClass('w', loc),

--- a/core/src/test/scala/weaponregex/internal/mutator/BoundaryMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/internal/mutator/BoundaryMutatorTest.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptyList
 import weaponregex.internal.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.internal.parser.Parser
@@ -9,7 +10,7 @@ class BoundaryMutatorTest extends munit.FunSuite {
     val pattern = "^abc^def^"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(BOLRemoval)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(BOLRemoval)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "abc^def^",
@@ -18,22 +19,22 @@ class BoundaryMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not remove escaped BOL") {
     val pattern = "\\^abc"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(BOLRemoval)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(BOLRemoval)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Removes EOL") {
     val pattern = "$abc$def$"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(EOLRemoval)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(EOLRemoval)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "abc$def$",
@@ -42,22 +43,22 @@ class BoundaryMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not remove escaped EOL") {
     val pattern = "abc\\$"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(EOLRemoval)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(EOLRemoval)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Changes BOL to BOI") {
     val pattern = "^abc^def^ghi\\^"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(BOL2BOI)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(BOL2BOI)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       """\Aabc^def^ghi\^""",
@@ -66,22 +67,22 @@ class BoundaryMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not change escaped BOL") {
     val pattern = "\\^abc"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(BOL2BOI)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(BOL2BOI)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Changes EOL to EOI") {
     val pattern = "$abc$def$ghi\\$"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(EOL2EOI)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(EOL2EOI)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       """\zabc$def$ghi\$""",
@@ -90,14 +91,14 @@ class BoundaryMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not change escaped EOL") {
     val pattern = "abc\\$"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(EOL2EOI)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(EOL2EOI)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 }

--- a/core/src/test/scala/weaponregex/internal/mutator/CapturingMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/internal/mutator/CapturingMutatorTest.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptyList
 import weaponregex.internal.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.internal.parser.Parser
@@ -10,28 +11,28 @@ class CapturingMutatorTest extends munit.FunSuite {
     val pattern = "(hello)"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
+    val mutants: Seq[Mutant] = parsedTree.mutate(NonEmptyList.one(GroupToNCGroup))
 
     val expected: Seq[String] = Seq("(?:hello)")
 
     assertEquals(clue(mutants).length, expected.length)
-    assertEquals(clue(mutants) map (_.pattern), expected)
+    assertEquals(clue(mutants).map(_.pattern), expected)
   }
 
   test("Does not change escaped capturing groups") {
     val pattern = "\\(hello\\)"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[Mutant] = parsedTree.mutate(Seq(GroupToNCGroup))
+    val mutants: Seq[Mutant] = parsedTree.mutate(NonEmptyList.one(GroupToNCGroup))
 
-    assertEquals(clue(mutants), Nil)
+    assertEquals(mutants, Nil)
   }
 
   test("Negates lookaround constructs") {
     val pattern = "(?=abc)(?!abc)(?<=abc)(?<!abc)"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(LookaroundNegation)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(LookaroundNegation)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "(?!abc)(?!abc)(?<=abc)(?<!abc)",
@@ -41,6 +42,6 @@ class CapturingMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 }

--- a/core/src/test/scala/weaponregex/internal/mutator/CharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/internal/mutator/CharClassMutatorTest.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptyList
 import weaponregex.internal.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.internal.parser.Parser
@@ -9,7 +10,7 @@ class CharClassMutatorTest extends munit.FunSuite {
     val pattern = "[[abc][^abc]]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassNegation)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassNegation)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "[^[abc][^abc]]",
@@ -18,22 +19,22 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not mutate escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassNegation)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassNegation)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Removes children of Character Classes") {
     val pattern = "[ab0-9[A-Z][cd]]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassChildRemoval)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "[b0-9[A-Z][cd]]",
@@ -46,14 +47,14 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Removes children of Naked Character Classes") {
     val pattern = "[abc&&def&&[gh]]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassChildRemoval)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "[bc&&def&&[gh]]",
@@ -67,22 +68,22 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not mutate (remove children) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassChildRemoval)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassChildRemoval)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Character Class to any char") {
     val pattern = "[abc[0-9]]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassAnyChar)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassAnyChar)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       """[\w\W]""",
@@ -90,22 +91,22 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not mutate (change to any char) escaped Character Classes") {
     val pattern = "\\[abc\\]abc"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassAnyChar)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassAnyChar)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Character Class Modify Range [b-y][B-Y][1-8]") {
     val pattern = "[b-y][B-Y][1-8]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       // [b-y] -> [a-y] or [c-y] or [b-z] or [b-x]
@@ -126,14 +127,14 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Character Class Modify Range [a-y][A-Y][0-8]") {
     val pattern = "[a-y][A-Y][0-8]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       // [a-y] -> [b-y] or [a-z] or [a-x]
@@ -151,14 +152,14 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Character Class Modify Range [b-z][B-Z][1-9]") {
     val pattern = "[b-z][B-Z][1-9]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       // [b-z] -> [a-z] or [c-z] or [b-y]
@@ -176,14 +177,14 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Character Class Modify Range [a-z][A-Z][0-9]") {
     val pattern = "[a-z][A-Z][0-9]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       // [a-z] -> [b-z] or [a-y]
@@ -198,14 +199,14 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Character Class Modify Range [b-b][B-B][1-1]") {
     val pattern = "[b-b][B-B][1-1]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       // [b-b] -> [a-b] or [b-c]
@@ -220,14 +221,14 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Character Class Modify Range [a-a][A-A][0-0]") {
     val pattern = "[a-a][A-A][0-0]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       // [a-a] -> [a-b]
@@ -239,14 +240,14 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Character Class Modify Range [z-z][Z-Z][9-9]") {
     val pattern = "[z-z][Z-Z][9-9]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       // [z-z] -> [y-z]
@@ -258,30 +259,30 @@ class CharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not modify non alpha numeric ranges") {
     val pattern = "[!-#][a-#][!-z][A-#][!-Z][1-#][!-8]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Does not modify ranges with letters and digits mixed") {
     val pattern = "[a-8][1-z][A-8][1-Z]"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Does not mutate (modify range) escaped Character Classes") {
     val pattern = "\\[a-z\\]a-z"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(CharClassRangeModification)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(CharClassRangeModification)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 }

--- a/core/src/test/scala/weaponregex/internal/mutator/PredefCharClassMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/internal/mutator/PredefCharClassMutatorTest.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptyList
 import weaponregex.internal.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.internal.parser.Parser
@@ -9,7 +10,7 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
     val pattern = """\w\W\d\D\s\S"""
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNegation)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(PredefCharClassNegation)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       """\W\W\d\D\s\S""",
@@ -21,22 +22,22 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not mutate (negate) similar characters") {
     val pattern = "wWdDsS"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNegation)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(PredefCharClassNegation)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Nullifies Predefined Character Class") {
     val pattern = """\w\W\d\D\s\S"""
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNullification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(PredefCharClassNullification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       """w\W\d\D\s\S""",
@@ -48,22 +49,22 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not mutate (nullify) similar characters") {
     val pattern = "wWdDsS"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassNullification)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(PredefCharClassNullification)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Changes Predefined Character Class to Any Char") {
     val pattern = """\w\W\d\D\s\S"""
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassAnyChar)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(PredefCharClassAnyChar)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       """[\w\W]\W\d\D\s\S""",
@@ -75,22 +76,22 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not mutate (change) similar characters") {
     val pattern = "wWdDsS"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(PredefCharClassAnyChar)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(PredefCharClassAnyChar)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Negates Unicode Character Class with lone property") {
     val pattern = """\p{Alpha}\P{Alpha}"""
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(UnicodeCharClassNegation)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(UnicodeCharClassNegation)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       """\P{Alpha}\P{Alpha}""",
@@ -98,14 +99,14 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Negates Unicode Character Class with property and value") {
     val pattern = """\p{Script_Extensions=Latin}\P{Script_Extensions=Latin}"""
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(UnicodeCharClassNegation)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(UnicodeCharClassNegation)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       """\P{Script_Extensions=Latin}\P{Script_Extensions=Latin}""",
@@ -113,6 +114,6 @@ class PredefCharClassMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 }

--- a/core/src/test/scala/weaponregex/internal/mutator/QuantifierMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/internal/mutator/QuantifierMutatorTest.scala
@@ -1,5 +1,6 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptyList
 import weaponregex.internal.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeMutator
 import weaponregex.internal.parser.Parser
@@ -9,7 +10,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}g"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierRemoval)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "ab*c+d{1}e{1,}f{1,2}g",
@@ -21,22 +22,22 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not remove escaped greedy quantifiers") {
     val pattern = """a\?b\*c\+d\{1\}e\{1,\}f\{1,2\}g"""
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierRemoval)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Removes reluctant quantifier") {
     val pattern = "a??b*?c+?d{1}?e{1,}?f{1,2}?g"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierRemoval)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "ab*?c+?d{1}?e{1,}?f{1,2}?g",
@@ -48,22 +49,22 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not remove escaped greedy quantifiers") {
     val pattern = """a\?\?b\*\?c\+\?d\{1\}\?e\{1,\}\?f\{1,2\}\?g"""
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierRemoval)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Removes possessive quantifier") {
     val pattern = "a?+b*+c++d{1}+e{1,}+f{1,2}+"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierRemoval)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "ab*+c++d{1}+e{1,}+f{1,2}+",
@@ -75,22 +76,22 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Does not remove escaped possessive quantifiers") {
     val pattern = """a\?\+b\*\+c\+\+d\{1\}\+e\{1,\}\+f\{1,2\}\+g"""
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierRemoval)) map (_.pattern)
-    assertEquals(clue(mutants), Nil)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierRemoval)).map(_.pattern)
+    assertEquals(mutants, Nil)
   }
 
   test("Changes quantifier {n}") {
     val pattern = "a{1}"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNChange)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierNChange)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "a{0,1}",
@@ -98,14 +99,14 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Modifies quantifier {n,}") {
     val pattern = "a{0,}b{1,}"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierNOrMoreModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "a{1,}b{1,}",
@@ -114,14 +115,14 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("QuantifierNOrMoreModification Does not mutate quantifier {n} and {n,m}") {
     val pattern = "a{3}b{4,9}"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierNOrMoreModification)).map(_.pattern)
 
     assertEquals(clue(mutants).length, 0)
   }
@@ -130,19 +131,19 @@ class QuantifierMutatorTest extends munit.FunSuite {
     val pattern = "a{1,}"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreChange)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierNOrMoreChange)).map(_.pattern)
 
     val expected: Seq[String] = Seq("a{1}")
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("QuantifierNOrMoreChange Does not mutate quantifier {n} and {n,m}") {
     val pattern = "a{3}b{4,9}"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNOrMoreChange)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierNOrMoreChange)).map(_.pattern)
 
     assertEquals(clue(mutants).length, 0)
   }
@@ -151,7 +152,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
     val pattern = "a{0,0}b{0,1}c{1,2}"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNMModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierNMModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "a{0,1}b{0,1}c{1,2}",
@@ -165,14 +166,14 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("QuantifierNMModification Does not mutate quantifier {n} and {n,}") {
     val pattern = "a{3}b{4,}"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierNMModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierNMModification)).map(_.pattern)
 
     assertEquals(clue(mutants).length, 0)
   }
@@ -181,7 +182,7 @@ class QuantifierMutatorTest extends munit.FunSuite {
     val pattern = "a?b*c+"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierShortModification)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierShortModification)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "a{1,1}b*c+",
@@ -193,14 +194,14 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Changes short quantifier") {
     val pattern = "a*b+"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierShortChange)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierShortChange)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "a{0}b+",
@@ -208,14 +209,14 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 
   test("Adds reluctant to greedy quantifier") {
     val pattern = "a?b*c+d{1}e{1,}f{1,2}"
     val parsedTree = Parser(pattern).getOrFail
 
-    val mutants: Seq[String] = parsedTree.mutate(Seq(QuantifierReluctantAddition)) map (_.pattern)
+    val mutants: Seq[String] = parsedTree.mutate(NonEmptyList.one(QuantifierReluctantAddition)).map(_.pattern)
 
     val expected: Seq[String] = Seq(
       "a??b*c+d{1}e{1,}f{1,2}",
@@ -227,6 +228,6 @@ class QuantifierMutatorTest extends munit.FunSuite {
     )
 
     assertEquals(clue(mutants).length, expected.length)
-    expected foreach (m => assert(clue(mutants) contains clue(m)))
+    expected.foreach(m => assert(clue(mutants).contains(clue(m))))
   }
 }

--- a/core/src/test/scala/weaponregex/internal/mutator/RegexTreeMutatorTest.scala
+++ b/core/src/test/scala/weaponregex/internal/mutator/RegexTreeMutatorTest.scala
@@ -1,5 +1,7 @@
 package weaponregex.internal.mutator
 
+import cats.data.NonEmptySet
+import cats.syntax.all.*
 import munit.Location
 import weaponregex.internal.extension.EitherExtension.LeftStringEitherTest
 import weaponregex.internal.extension.RegexTreeExtension.RegexTreeMutator
@@ -15,64 +17,64 @@ class RegexTreeMutatorTest extends munit.FunSuite {
     Parser(regex).getOrFail
 
   test("Filters mutators with level 1") {
-    val levels = Seq(1)
-    val mutants = tree.mutate(BuiltinMutators.all, levels)
+    val levels = NonEmptySet.of(1)
+    val mutants = tree.mutate(BuiltinMutators.all, levels.some)
 
-    mutants foreach (mutant => assert(levels exists (clue(mutant).levels contains _)))
+    mutants.foreach(mutant => assert(levels.exists(clue(mutant).levels.contains(_))))
     assert(clue(mutants) exists (_.levels.length != 1))
   }
 
   test("Filters mutators with level 2") {
-    val levels = Seq(2)
-    val mutants = tree.mutate(BuiltinMutators.all, levels)
+    val levels = NonEmptySet.of(2)
+    val mutants = tree.mutate(BuiltinMutators.all, levels.some)
 
-    mutants foreach (mutant => assert(levels exists (clue(mutant).levels contains _)))
+    mutants.foreach(mutant => assert(levels.exists(clue(mutant).levels.contains(_))))
     assert(clue(mutants) exists (_.levels.length != 1))
   }
 
   test("Filters mutators with level 3") {
-    val levels = Seq(3)
-    val mutants = tree.mutate(BuiltinMutators.all, levels)
+    val levels = NonEmptySet.of(3)
+    val mutants = tree.mutate(BuiltinMutators.all, levels.some)
 
-    mutants foreach (mutant => assert(levels exists (clue(mutant).levels contains _)))
+    mutants.foreach(mutant => assert(levels.exists(clue(mutant).levels.contains(_))))
     assert(clue(mutants) exists (_.levels.length != 1))
   }
 
   test("Filters mutators with levels 1, 2") {
-    val levels = Seq(1, 2)
-    val mutants = tree.mutate(BuiltinMutators.all, levels)
+    val levels = NonEmptySet.of(1, 2)
+    val mutants = tree.mutate(BuiltinMutators.all, levels.some)
 
-    mutants foreach (mutant => assert(levels exists (clue(mutant).levels contains _)))
+    mutants.foreach(mutant => assert(levels.exists(clue(mutant).levels.contains(_))))
     assert(clue(mutants) exists (_.levels.length == 1))
   }
 
   test("Filters mutators with levels 2, 3") {
-    val levels = Seq(2, 3)
-    val mutants = tree.mutate(BuiltinMutators.all, levels)
+    val levels = NonEmptySet.of(2, 3)
+    val mutants = tree.mutate(BuiltinMutators.all, levels.some)
 
-    mutants foreach (mutant => assert(levels exists (clue(mutant).levels contains _)))
+    mutants.foreach(mutant => assert(levels.exists(clue(mutant).levels.contains(_))))
     assert(clue(mutants) exists (_.levels.length == 1))
   }
 
   test("Filters mutators with levels 1, 3") {
-    val levels = Seq(1, 3)
-    val mutants = tree.mutate(BuiltinMutators.all, levels)
+    val levels = NonEmptySet.of(1, 3)
+    val mutants = tree.mutate(BuiltinMutators.all, levels.some)
 
-    mutants foreach (mutant => assert(levels exists (clue(mutant).levels contains _)))
+    mutants.foreach(mutant => assert(levels.exists(clue(mutant).levels.contains(_))))
     assert(clue(mutants) exists (_.levels.length == 1))
   }
 
   test("Filters mutators with levels 1, 2, 3") {
-    val levels = Seq(1, 2, 3)
-    val mutants = tree.mutate(BuiltinMutators.all, levels)
+    val levels = NonEmptySet.of(1, 2, 3)
+    val mutants = tree.mutate(BuiltinMutators.all, levels.some)
 
-    mutants foreach (mutant => assert(levels exists (clue(mutant).levels contains _)))
+    mutants.foreach(mutant => assert(levels.exists(clue(mutant).levels.contains(_))))
     assert(clue(mutants) exists (_.levels.length == 1))
   }
 
   test("Filters mutators with unsupported levels") {
-    val levels = Seq(100, 1000)
-    val mutants = tree.mutate(BuiltinMutators.all, levels)
+    val levels = NonEmptySet.of(100, 1000)
+    val mutants = tree.mutate(BuiltinMutators.all, levels.some)
 
     assert(clue(mutants).isEmpty)
   }
@@ -80,7 +82,7 @@ class RegexTreeMutatorTest extends munit.FunSuite {
   test("Mutates with all mutators by default") {
     val mutants = tree.mutate()
     val mutantNames = mutants.map(_.name)
-    BuiltinMutators.all foreach (mutator =>
+    BuiltinMutators.all.toList.foreach(mutator =>
       assert(mutantNames contains mutator.name, clue = (mutator.name, mutantNames))
     )
   }
@@ -89,15 +91,15 @@ class RegexTreeMutatorTest extends munit.FunSuite {
     val mutants = tree.mutate(BuiltinMutators.all)
     val mutantNames = mutants.map(_.name)
 
-    BuiltinMutators.all foreach (mutator =>
+    BuiltinMutators.all.toList.foreach(mutator =>
       assert(mutantNames contains mutator.name, clue = (mutator.name, mutantNames))
     )
   }
 
   test("Uses only the given mutators") {
     val usedMutators = BuiltinMutators.all.take(5)
-    val excludedMutators = BuiltinMutators.all.drop(5)
-    val mutants = tree.mutate(usedMutators)
+    val excludedMutators = BuiltinMutators.all.toList.drop(5)
+    val mutants = tree.mutate(usedMutators.toNel.get)
     val mutantNames = mutants.map(_.name)
 
     usedMutators foreach (mutator => assert(mutantNames contains mutator.name, clue = (mutator.name, mutantNames)))
@@ -109,12 +111,12 @@ class RegexTreeMutatorTest extends munit.FunSuite {
 
   test("Uses only the given mutators with mutation levels filtering") {
     val usedMutators = BuiltinMutators.all.take(5)
-    val excludedMutators = BuiltinMutators.all.drop(5)
-    val levels = Seq(2, 3)
-    val mutants = tree.mutate(usedMutators, levels)
+    val excludedMutators = BuiltinMutators.all.toList.drop(5)
+    val levels = NonEmptySet.of(2, 3)
+    val mutants = tree.mutate(usedMutators.toNel.get, levels.some)
     val mutantNames = mutants.map(_.name)
 
-    usedMutators.filter(_.levels exists (levels contains _)) foreach (mutator =>
+    usedMutators.filter(_.levels.exists(levels.contains(_))) foreach (mutator =>
       assert(mutantNames contains mutator.name, clue = (mutator.name, mutantNames))
     )
 
@@ -122,18 +124,13 @@ class RegexTreeMutatorTest extends munit.FunSuite {
       assert(!(mutantNames contains mutator.name), clue = (mutator.name, mutantNames))
     )
 
-    mutants foreach (mutant => assert(levels exists (clue(mutant).levels contains _)))
-  }
-
-  test("Used empty sequence of mutators") {
-    val mutants = tree.mutate(Nil)
-    assert(clue(mutants).isEmpty)
+    mutants.foreach(mutant => assert(levels.exists(clue(mutant).levels.contains(_))))
   }
 
   test("Adds correct replacement") {
     val regex = """^a{4,}[ab]$"""
     val tree = Parser(regex).getOrFail
-    val mutants = tree.mutate(BuiltinMutators.atLevels(Seq(2)))
+    val mutants = tree.mutate(BuiltinMutators.atLevels(NonEmptySet.one(2)).get)
 
     val expected = Seq[(String, String, Location)](
       ("a{4,}[ab]$", "", implicitly),

--- a/core/src/test/scala/weaponregex/mutator/BuiltinMutatorsTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/BuiltinMutatorsTest.scala
@@ -1,52 +1,57 @@
 package weaponregex.mutator
 
+import cats.data.NonEmptySet
+import cats.syntax.all.*
+
 class BuiltinMutatorsTest extends munit.FunSuite {
   test("Convert to a map by mutator class name") {
     val nameMap = BuiltinMutators.byName
-    assertEquals(nameMap.keys.size, BuiltinMutators.all.length)
-    BuiltinMutators.all foreach (mutator =>
-      assertEquals(nameMap(mutator.getClass.getSimpleName.stripSuffix("$")), mutator)
+    assertEquals(nameMap.keys.size, BuiltinMutators.all.length.toLong)
+    BuiltinMutators.all.toList.foreach(mutator =>
+      assertEquals(nameMap(mutator.getClass.getSimpleName.stripSuffix("$")).get, mutator)
     )
   }
 
   test("Convert to a map by mutation levels") {
     val levelMap = BuiltinMutators.byLevel
-    BuiltinMutators.all foreach (mutator =>
-      mutator.levels foreach (level => assert(levelMap(level) contains mutator, clue = (levelMap(level), mutator)))
+    BuiltinMutators.all.toList.foreach(mutator =>
+      mutator.levels.toList.foreach(level =>
+        assert(levelMap(level).get.toList.contains(mutator), clue = (levelMap(level), mutator))
+      )
     )
   }
 
   test("Get mutator in a single level") {
     val level = 1
-    val mutators = BuiltinMutators.atLevel(level)
-    mutators foreach (mutator => assert(clue(mutator).levels contains level))
+    val mutators = BuiltinMutators.atLevel(level).get
+    mutators.toList.foreach(mutator => assert(clue(mutator).levels.contains(level)))
   }
 
   test("Get mutator in a single non-existed level") {
     val level = -1
     val mutators = BuiltinMutators.atLevel(level)
-    assert(clue(mutators) == Nil)
+    assertEquals(clue(mutators), None)
   }
 
   test("Get mutator in multiple levels") {
-    val levels = Seq(1, 2, 3)
-    val mutators = BuiltinMutators.atLevels(levels)
-    mutators foreach (mutator => assert(levels exists (clue(mutator).levels contains _)))
+    val levels = NonEmptySet.of(1, 2, 3)
+    val mutators = BuiltinMutators.atLevels(levels).get.toList
+    mutators.foreach(mutator => assert(levels.exists(clue(mutator).levels.contains(_))))
   }
 
   test("Get mutator in multiple levels with some non-existed levels") {
-    val levels = Seq(1, 2, 3)
-    val badLevels = Seq(-1, -2, -3)
-    val mutators = BuiltinMutators.atLevels(levels ++ badLevels)
-    mutators foreach (mutator => {
-      assert(levels exists (clue(mutator).levels contains _))
-      assert(!(badLevels exists (clue(mutator).levels contains _)))
+    val levels = NonEmptySet.of(1, 2, 3)
+    val badLevels = NonEmptySet.of(-1, -2, -3)
+    val mutators = BuiltinMutators.atLevels(levels ++ badLevels).get
+    mutators.toList.foreach(mutator => {
+      assert(levels.exists(clue(mutator).levels.contains(_)))
+      assert(!badLevels.exists(clue(mutator).levels.contains(_)))
     })
   }
 
   test("Get mutator in non-existed multiple levels") {
-    val levels = Seq(-1, -2, -3)
+    val levels = NonEmptySet.of(-1, -2, -3)
     val mutators = BuiltinMutators.atLevels(levels)
-    assert(clue(mutators) == Nil)
+    assertEquals(clue(mutators), None)
   }
 }

--- a/core/src/test/scala/weaponregex/mutator/MutatorTest.scala
+++ b/core/src/test/scala/weaponregex/mutator/MutatorTest.scala
@@ -4,11 +4,11 @@ import weaponregex.internal.constant.RegexTreeStubs.LOCATION
 
 class MutatorTest extends munit.FunSuite {
   test("Mutator name is non-empty") {
-    BuiltinMutators.all foreach (mutator => assert(clue(mutator).name.nonEmpty))
+    BuiltinMutators.all.toList.foreach(mutator => assert(clue(mutator).name.nonEmpty))
   }
 
   test("Mutator description starts with a location") {
-    BuiltinMutators.all foreach (mutator =>
+    BuiltinMutators.all.toList.foreach(mutator =>
       assert(clue(mutator.description("original", "mutated", LOCATION)).startsWith(LOCATION.show))
     )
   }

--- a/core/src/test/scalajs/weaponregex/internal/extension/MutationOptionsExtensionTest.scala
+++ b/core/src/test/scalajs/weaponregex/internal/extension/MutationOptionsExtensionTest.scala
@@ -1,5 +1,7 @@
 package weaponregex.internal.extension
 
+import cats.data.NonEmptySet
+import cats.syntax.all.*
 import weaponregex.internal.extension.MutationOptionsExtension.MutationOptionsConverter
 import weaponregex.model.MutationOptions
 import weaponregex.mutator.{BuiltinMutators, BuiltinMutatorsJS}
@@ -13,7 +15,7 @@ class MutationOptionsExtensionTest extends munit.FunSuite {
     val (mutators, mutationLevels, flavor) = options.toScala
 
     assertEquals(mutators, BuiltinMutators.all)
-    assertEquals(mutationLevels, null)
+    assertEquals(mutationLevels, None)
     assertEquals(flavor, ParserFlavorJS)
   }
 
@@ -24,8 +26,8 @@ class MutationOptionsExtensionTest extends munit.FunSuite {
     val options = new MutationOptions(mutators = mutatorsIn)
     val (mutators, mutationLevels, flavor) = options.toScala
 
-    assertEquals(mutators, BuiltinMutators.all.take(numMutators))
-    assertEquals(mutationLevels, null)
+    assertEquals(mutators.toList, BuiltinMutators.all.take(numMutators))
+    assertEquals(mutationLevels, None)
     assertEquals(flavor, ParserFlavorJS)
   }
 
@@ -36,7 +38,7 @@ class MutationOptionsExtensionTest extends munit.FunSuite {
     val (mutators, mutationLevels, flavor) = options.toScala
 
     assertEquals(mutators, BuiltinMutators.all)
-    assertEquals(mutationLevels, levelsIn.toSeq)
+    assertEquals(mutationLevels, NonEmptySet.of(2, 3).some)
     assertEquals(flavor, ParserFlavorJS)
   }
 
@@ -47,7 +49,7 @@ class MutationOptionsExtensionTest extends munit.FunSuite {
     val (mutators, mutationLevels, flavor) = options.toScala
 
     assertEquals(mutators, BuiltinMutators.all)
-    assertEquals(mutationLevels, null)
+    assertEquals(mutationLevels, None)
     assertEquals(flavor, flavorIn)
   }
 
@@ -60,8 +62,8 @@ class MutationOptionsExtensionTest extends munit.FunSuite {
     val options = new MutationOptions(mutatorsIn, levelsIn, flavorIn)
     val (mutators, mutationLevels, flavor) = options.toScala
 
-    assertEquals(mutators, BuiltinMutators.all.take(numMutators))
-    assertEquals(mutationLevels, levelsIn.toSeq)
+    assertEquals(mutators.toList, BuiltinMutators.all.take(numMutators))
+    assertEquals(mutationLevels, NonEmptySet.of(2, 3).some)
     assertEquals(flavor, flavorIn)
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ Mutate!
 import weaponregex.WeaponRegeX
 
 WeaponRegeX.mutate("^abc(d+|[xyz])$") match {
-    case Right(mutants) => mutants map (_.pattern)
+    case Right(mutants) => mutants.map(_.pattern)
     case Left(e)        => throw new RuntimeException(e)
 }
 ```
@@ -57,7 +57,7 @@ import wrx from 'weapon-regex';
 let mutants = wrx.mutate('^abc(d+|[xyz])$');
 
 mutants.forEach((mutant) => {
-    console.log(mutant.pattern);
+  console.log(mutant.pattern);
 });
 ```
 
@@ -72,16 +72,17 @@ Note: as of 1.0.0 weapon-regex uses ES Modules.
 The `mutate` function has the following signature:
 
 ```scala mdoc
+import cats.data.{NonEmptyList, NonEmptySet}
 import weaponregex.model.mutation._
 import weaponregex.mutator.BuiltinMutators
 import weaponregex.parser.{ParserFlavor, ParserFlavorJVM}
 
 def mutate(
-              pattern       : String,
-              mutators      : Seq[TokenMutator] = BuiltinMutators.all,
-              mutationLevels: Seq[Int] = null,
-              flavor        : ParserFlavor = ParserFlavorJVM
-          ): Either[String, Seq[Mutant]] = ???
+    pattern       : String,
+    mutators      : NonEmptyList[TokenMutator] = BuiltinMutators.all,
+    mutationLevels: Option[NonEmptySet[Int]] = None,
+    flavor        : ParserFlavor = ParserFlavorJVM
+): Either[String, Seq[Mutant]] = ???
 ```
 
 With the `mutators` argument you can give a select list of mutators that should be used in
@@ -106,9 +107,9 @@ which parser flavor should be used in the mutation process:
 import wrx from 'weapon-regex';
 
 let mutants = wrx.mutate('^abc(d+|[xyz])$', 'u', {
-    mutators: Array.from(wrx.mutators.values()),
-    mutationLevels: [1, 2, 3],
-    flavor: wrx.ParserFlavorJS,
+  mutators: Array.from(wrx.mutators.values()),
+  mutationLevels: [1, 2, 3],
+  flavor: wrx.ParserFlavorJS,
 });
 ```
 
@@ -123,30 +124,30 @@ This function will return a JavaScript Array of `Mutant` if it can be parsed, or
 
 All the supported mutators and at which mutation level they appear are shown in the table below.
 
-| Name                                                            | 1 | 2 | 3 |
-|-----------------------------------------------------------------|---|---|---|
-| [BOLRemoval](#bolremoval)                                       | ✅ | ✅ | ✅ |
-| [EOLRemoval](#eolremoval)                                       | ✅ | ✅ | ✅ |
-| [BOL2BOI](#bol2boi)                                             |   | ✅ | ✅ |
-| [EOL2EOI](#eol2eoi)                                             |   | ✅ | ✅ |
-| [CharClassNegation](#charclassnegation)                         | ✅ |
-| [CharClassChildRemoval](#charclasschildremoval)                 |   | ✅ | ✅ |
-| [CharClassAnyChar](#charclassanychar)                           |   | ✅ | ✅ |
-| [CharClassRangeModification](#charclassrangemodification)       |   |   | ✅ |
-| [PredefCharClassNegation](#predefcharclassnegation)             | ✅ |
-| [PredefCharClassNullification](#predefcharclassnullification)   |   | ✅ | ✅ |
-| [PredefCharClassAnyChar](#predefcharclassanychar)               |   | ✅ | ✅ |
-| [UnicodeCharClassNegation](#unicodecharclassnegation)           | ✅ |
-| [QuantifierRemoval](#quantifierremoval)                         | ✅ |
-| [QuantifierNChange](#quantifiernchange)                         |   | ✅ | ✅ |
-| [QuantifierNOrMoreModification](#quantifiernormoremodification) |   | ✅ | ✅ |
-| [QuantifierNOrMoreChange](#quantifiernormorechange)             |   | ✅ | ✅ |
-| [QuantifierNMModification](#quantifiernmmodification)           |   | ✅ | ✅ |
-| [QuantifierShortModification](#quantifiershortmodification)     |   | ✅ | ✅ |
-| [QuantifierShortChange](#quantifiershortchange)                 |   | ✅ | ✅ |
-| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |   |   | ✅ |
-| [GroupToNCGroup](#grouptoncgroup)                               |   | ✅ | ✅ |
-| [LookaroundNegation](#lookaroundnegation)                       | ✅ | ✅ | ✅ |
+| Name                                                            | 1   | 2   | 3   |
+| --------------------------------------------------------------- | --- | --- | --- |
+| [BOLRemoval](#bolremoval)                                       | ✅  | ✅  | ✅  |
+| [EOLRemoval](#eolremoval)                                       | ✅  | ✅  | ✅  |
+| [BOL2BOI](#bol2boi)                                             |     | ✅  | ✅  |
+| [EOL2EOI](#eol2eoi)                                             |     | ✅  | ✅  |
+| [CharClassNegation](#charclassnegation)                         | ✅  |
+| [CharClassChildRemoval](#charclasschildremoval)                 |     | ✅  | ✅  |
+| [CharClassAnyChar](#charclassanychar)                           |     | ✅  | ✅  |
+| [CharClassRangeModification](#charclassrangemodification)       |     |     | ✅  |
+| [PredefCharClassNegation](#predefcharclassnegation)             | ✅  |
+| [PredefCharClassNullification](#predefcharclassnullification)   |     | ✅  | ✅  |
+| [PredefCharClassAnyChar](#predefcharclassanychar)               |     | ✅  | ✅  |
+| [UnicodeCharClassNegation](#unicodecharclassnegation)           | ✅  |
+| [QuantifierRemoval](#quantifierremoval)                         | ✅  |
+| [QuantifierNChange](#quantifiernchange)                         |     | ✅  | ✅  |
+| [QuantifierNOrMoreModification](#quantifiernormoremodification) |     | ✅  | ✅  |
+| [QuantifierNOrMoreChange](#quantifiernormorechange)             |     | ✅  | ✅  |
+| [QuantifierNMModification](#quantifiernmmodification)           |     | ✅  | ✅  |
+| [QuantifierShortModification](#quantifiershortmodification)     |     | ✅  | ✅  |
+| [QuantifierShortChange](#quantifiershortchange)                 |     | ✅  | ✅  |
+| [QuantifierReluctantAddition](#quantifierreluctantaddition)     |     |     | ✅  |
+| [GroupToNCGroup](#grouptoncgroup)                               |     | ✅  | ✅  |
+| [LookaroundNegation](#lookaroundnegation)                       | ✅  | ✅  | ✅  |
 
 ## Boundary Mutators
 
@@ -155,7 +156,7 @@ All the supported mutators and at which mutation level they appear are shown in 
 Remove the beginning of line character `^`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `^abc`   | `abc`   |
 
 [Back to table 🔝](#supported-mutators)
@@ -165,7 +166,7 @@ Remove the beginning of line character `^`.
 Remove the end of line character `$`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `abc$`   | `abc`   |
 
 [Back to table 🔝](#supported-mutators)
@@ -175,7 +176,7 @@ Remove the end of line character `$`.
 Change the beginning of line character `^` to a beginning of input character `\A`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `^abc`   | `\Aabc` |
 
 [Back to table 🔝](#supported-mutators)
@@ -185,7 +186,7 @@ Change the beginning of line character `^` to a beginning of input character `\A
 Change the end of line character `^` to a end of input character `\z`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `abc$`   | `abc\z` |
 
 [Back to table 🔝](#supported-mutators)
@@ -197,7 +198,7 @@ Change the end of line character `^` to a end of input character `\z`.
 Flips the sign of a character class.
 
 | Original | Mutated  |
-|----------|----------|
+| -------- | -------- |
 | `[abc]`  | `[^abc]` |
 | `[^abc]` | `[abc]`  |
 
@@ -208,7 +209,7 @@ Flips the sign of a character class.
 Remove a child of a character class.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `[abc]`  | `[bc]`  |
 | `[abc]`  | `[ac]`  |
 | `[abc]`  | `[ab]`  |
@@ -220,7 +221,7 @@ Remove a child of a character class.
 Change a character class to a character class which matches any character.
 
 | Original | Mutated  |
-|----------|----------|
+| -------- | -------- |
 | `[abc]`  | `[\w\W]` |
 
 [Back to table 🔝](#supported-mutators)
@@ -230,7 +231,7 @@ Change a character class to a character class which matches any character.
 Change the high and low of a range by one in both directions if possible.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `[b-y]`  | `[a-y]` |
 | `[b-y]`  | `[c-y]` |
 | `[b-y]`  | `[b-z]` |
@@ -245,7 +246,7 @@ Change the high and low of a range by one in both directions if possible.
 Flips the sign of a predefined character class. All the predefined character classes are shown in the table below.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `\d`     | `\D`    |
 | `\D`     | `\d`    |
 | `\s`     | `\S`    |
@@ -260,7 +261,7 @@ Flips the sign of a predefined character class. All the predefined character cla
 Remove the backslash from a predefined character class such as `\w`.
 
 | Original | Mutated |
-|----------|---------|
+| -------- | ------- |
 | `\d`     | `d`     |
 | `\D`     | `D`     |
 | `\s`     | `s`     |
@@ -276,7 +277,7 @@ Change a predefined character class to a character class containing the predefin
 negation.
 
 | Original | Mutated  |
-|----------|----------|
+| -------- | -------- |
 | `\d`     | `[\d\D]` |
 | `\D`     | `[\D\d]` |
 | `\s`     | `[\s\S]` |
@@ -291,7 +292,7 @@ negation.
 Flips the sign of a Unicode character class.
 
 | Original    | Mutated     |
-|-------------|-------------|
+| ----------- | ----------- |
 | `\p{Alpha}` | `\P{Alpha}` |
 | `\P{Alpha}` | `\p{Alpha}` |
 
@@ -305,7 +306,7 @@ Remove a quantifier. This is done for all possible quantifiers, even ranges, and
 and possessive variants.
 
 | Original    | Mutated |
-|-------------|---------|
+| ----------- | ------- |
 | `abc?`      | `abc`   |
 | `abc*`      | `abc`   |
 | `abc+`      | `abc`   |
@@ -326,7 +327,7 @@ and possessive variants.
 Change the fixed amount quantifier to a couple of range variants.
 
 | Original | Mutated    |
-|----------|------------|
+| -------- | ---------- |
 | `abc{9}` | `abc{0,9}` |
 | `abc{9}` | `abc{9,}`  |
 
@@ -338,7 +339,7 @@ Change the `n` to infinity range quantifier to a couple of variants where the lo
 incremented and decremented by one.
 
 | Original  | Mutated    |
-|-----------|------------|
+| --------- | ---------- |
 | `abc{9,}` | `abc{8,}`  |
 | `abc{9,}` | `abc{10,}` |
 
@@ -349,7 +350,7 @@ incremented and decremented by one.
 Turn an `n` or more range quantifier into a fixed number quantifier.
 
 | Original  | Mutated  |
-|-----------|----------|
+| --------- | -------- |
 | `abc{9,}` | `abc{9}` |
 
 [Back to table 🔝](#supported-mutators)
@@ -360,7 +361,7 @@ Alter the `n` to `m` range quantifier by decrementing or incrementing the high a
 range by one.
 
 | Original   | Mutated     |
-|------------|-------------|
+| ---------- | ----------- |
 | `abc{3,9}` | `abc{2,9}`  |
 | `abc{3,9}` | `abc{4,9}`  |
 | `abc{3,9}` | `abc{3,8}`  |
@@ -375,7 +376,7 @@ variant (`{0,1}`, `{0,}`, `{1,}`), and applies the same mutations as mentioned i
 above.
 
 | Original | Mutated    |
-|----------|------------|
+| -------- | ---------- |
 | `abc?`   | `abc{1,1}` |
 | `abc?`   | `abc{0,0}` |
 | `abc?`   | `abc{0,2}` |
@@ -390,7 +391,7 @@ above.
 Change the shorthand quantifiers `*` and `+` to their fixed range quantifier variant.
 
 | Original | Mutated  |
-|----------|----------|
+| -------- | -------- |
 | `abc*`   | `abc{0}` |
 | `abc+`   | `abc{1}` |
 
@@ -401,7 +402,7 @@ Change the shorthand quantifiers `*` and `+` to their fixed range quantifier var
 Change greedy quantifiers to reluctant quantifiers.
 
 | Original    | Mutated      |
-|-------------|--------------|
+| ----------- | ------------ |
 | `abc?`      | `abc??`      |
 | `abc*`      | `abc*?`      |
 | `abc+`      | `abc+?`      |
@@ -418,7 +419,7 @@ Change greedy quantifiers to reluctant quantifiers.
 Change a normal group to a non-capturing group.
 
 | Original | Mutated   |
-|----------|-----------|
+| -------- | --------- |
 | `(abc)`  | `(?:abc)` |
 
 [Back to table 🔝](#supported-mutators)
@@ -428,7 +429,7 @@ Change a normal group to a non-capturing group.
 Flips the sign of a lookaround (lookahead, lookbehind) construct.
 
 | Original   | Mutated    |
-|------------|------------|
+| ---------- | ---------- |
 | `(?=abc)`  | `(?!abc)`  |
 | `(?!abc)`  | `(?=abc)`  |
 | `(?<=abc)` | `(?<!abc)` |

--- a/node/test/api.js
+++ b/node/test/api.js
@@ -67,6 +67,11 @@ describe('#mutate()', () => {
     assert.strictEqual(mutants.length, 4);
   });
 
+  it('Can mutate with `null` as options', () => {
+    const mutants = mutate('\\u{20}', null, null);
+    assert.strictEqual(mutants.length, 4);
+  });
+
   it('Can mutate with flags but no options param', () => {
     const mutants = mutate('\\u{20}', 'u');
     assert.strictEqual(mutants.length, 0);


### PR DESCRIPTION
For improved type-safety, use `cats.data.NonEmptyList` for the `mutators` argument and `Option[cats.data.NonEmptySet[Int]]` for the `mutationLevels` argument in the `mutate` function. This ensures that you cannot pass an empty sequence of mutators or mutation levels, and it makes it clear that at least one mutator or mutation level is required when using these arguments.

BREAKING: The `mutators` argument of the `mutate` function now requires a `cats.data.NonEmptyList[TokenMutator]` instead of a `Seq[TokenMutator]`, and the `mutationLevels` argument now requires an `Option[cats.data.NonEmptySet[Int]]` instead of a `Seq[Int]`. This means that you can no longer pass an empty sequence for mutators or mutation levels, and you need to wrap your arguments in `NonEmptyList` and `Option` respectively.
