### PR TITLE
fix: use js.Object for exported JS objects

### DIFF
--- a/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
+++ b/core/src/main/scalajs/weaponregex/WeaponRegeXJS.scala
@@ -40,7 +40,7 @@ object WeaponRegeXJS {
     val flagsOpt = flags.toOption.filterNot(_ == null).filterNot(_.isEmpty)
 
     Parser(pattern, flagsOpt, flavor) match {
-      case Right(tree) => tree.mutate(mutators, mutationLevels).map(MutantJS(_)).toJSArray
+      case Right(tree) => tree.mutate(mutators, mutationLevels).map(new MutantJS(_)).toJSArray
       case Left(msg)   => throw new RuntimeException(msg)
     }
   }

--- a/core/src/main/scalajs/weaponregex/model/mutation/MutantJS.scala
+++ b/core/src/main/scalajs/weaponregex/model/mutation/MutantJS.scala
@@ -2,7 +2,6 @@ package weaponregex.model.mutation
 
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.*
-import scala.scalajs.js.annotation.*
 
 /** A wrapper class for [[weaponregex.model.mutation.Mutant]] for exporting to JavaScript
   * @param mutant
@@ -10,8 +9,7 @@ import scala.scalajs.js.annotation.*
   * @note
   *   For JavaScript use only
   */
-@JSExportAll
-case class MutantJS(mutant: Mutant) {
+class MutantJS(mutant: Mutant) extends js.Object {
 
   /** The replacement pattern
     */

--- a/core/src/main/scalajs/weaponregex/model/mutation/TokenMutatorJS.scala
+++ b/core/src/main/scalajs/weaponregex/model/mutation/TokenMutatorJS.scala
@@ -1,10 +1,7 @@
 package weaponregex.model.mutation
 
-import weaponregex.internal.model.regextree.RegexTree
-
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.*
-import scala.scalajs.js.annotation.JSExport
 
 /** A wrapper class for [[weaponregex.model.mutation.TokenMutator]] for exporting to JavaScript
   * @param tokenMutator
@@ -12,23 +9,14 @@ import scala.scalajs.js.annotation.JSExport
   * @note
   *   For JavaScript use only
   */
-case class TokenMutatorJS(tokenMutator: TokenMutator) {
+final class TokenMutatorJS(val tokenMutator: TokenMutator) extends js.Object {
 
   /** The name of the mutator
     */
-  @JSExport
   val name: String = tokenMutator.name
 
   /** The mutation levels that the token mutator falls under
     */
-  @JSExport
   val levels: js.Array[Int] = tokenMutator.levels.toSortedSet.toJSArray
 
-  /** Mutate the given token
-    * @param token
-    *   Target token
-    * @return
-    *   Sequence of [[weaponregex.model.mutation.MutantJS]]
-    */
-  def mutate(token: RegexTree): Seq[MutantJS] = tokenMutator.mutate(token).map(MutantJS(_))
 }

--- a/core/src/main/scalajs/weaponregex/mutator/BuiltinMutatorsJS.scala
+++ b/core/src/main/scalajs/weaponregex/mutator/BuiltinMutatorsJS.scala
@@ -22,7 +22,7 @@ object BuiltinMutatorsJS {
     *   A JS array of [[weaponregex.model.mutation.TokenMutatorJS]]
     */
   private def toTokenMutatorJSArray(mutators: Option[NonEmptyList[TokenMutator]]): js.Array[TokenMutatorJS] =
-    mutators.map(_.toList.map(TokenMutatorJS(_))).orEmpty.toJSArray
+    mutators.map(_.toList.map(new TokenMutatorJS(_))).orEmpty.toJSArray
 
   /** JS Array of all built-in token mutators
     */
@@ -32,7 +32,7 @@ object BuiltinMutatorsJS {
     */
   @JSExportTopLevel("mutators")
   val byName: js.Map[String, TokenMutatorJS] =
-    BuiltinMutators.byName.transform((_, mutator) => TokenMutatorJS(mutator)).toSortedMap.toJSMap
+    BuiltinMutators.byName.transform((_, mutator) => new TokenMutatorJS(mutator)).toSortedMap.toJSMap
 
   /** JS Map that maps from mutation level number to token mutators in that level
     */


### PR DESCRIPTION
Creates nicer JS handling and `toString`'s
