### PR TITLE
perf(parser): reorder parsing to try most-common cases first

### DIFF
--- a/core/src/main/scala/weaponregex/internal/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/Parser.scala
@@ -315,15 +315,15 @@ abstract private[weaponregex] class Parser {
     */
   protected val classItem: P[RegexTree] = P.defer(
     P.oneOf(
-      charClass.backtrack ::
+      range.backtrack ::
+        charClassCharLiteral.backtrack ::
+        charClass.backtrack ::
         preDefinedCharClass.backtrack ::
         unicodeCharClass.backtrack ::
         metaCharacter.backtrack ::
-        range.backtrack ::
         hexEscCharConsumer ::
         octEscCharConsumer ::
-        quoteChar.backtrack ::
-        charClassCharLiteral :: Nil
+        quoteChar.backtrack :: Nil
     )
   )
 
@@ -666,7 +666,8 @@ abstract private[weaponregex] class Parser {
   protected val elementaryRE: P[RegexTree] =
     P.defer(
       P.oneOf(
-        capturing ::
+        charLiteral.backtrack ::
+          capturing ::
           anyDot ::
           preDefinedCharClass.backtrack ::
           unicodeCharClass.backtrack ::

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
@@ -64,20 +64,20 @@ private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean) exten
   override protected val classItem: P[RegexTree] =
     if (unicodeMode)
       P.oneOf(
-        preDefinedCharClass.backtrack ::
+        range.backtrack ::
+          charClassCharLiteral.backtrack ::
+          preDefinedCharClass.backtrack ::
           unicodeCharClass.backtrack ::
           P.defer(metaCharacter).backtrack ::
-          range.backtrack ::
-          quoteChar.backtrack ::
-          charClassCharLiteral :: Nil
+          quoteChar.backtrack :: Nil
       )
     else
       P.oneOf(
-        preDefinedCharClass.backtrack ::
+        range.backtrack ::
+          charClassCharLiteral.backtrack ::
+          preDefinedCharClass.backtrack ::
           P.defer(metaCharacter).backtrack ::
-          range.backtrack ::
-          quoteChar.backtrack ::
-          charClassCharLiteral :: Nil
+          quoteChar.backtrack :: Nil
       )
 
   /** Parse a group name
@@ -150,7 +150,8 @@ private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean) exten
   override protected val elementaryRE: P[RegexTree] =
     if (unicodeMode)
       P.oneOf(
-        capturing ::
+        charLiteral.backtrack ::
+          capturing ::
           anyDot ::
           preDefinedCharClass.backtrack ::
           unicodeCharClass.backtrack ::
@@ -162,7 +163,8 @@ private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean) exten
       )
     else
       P.oneOf(
-        capturing ::
+        charLiteral.backtrack ::
+          capturing ::
           anyDot ::
           preDefinedCharClass.backtrack ::
           boundary ::


### PR DESCRIPTION
~55% of all allocations were cats-parse error accumulation. This change tries the literal-character alternative first.

Together with #684 this improves performance quite a bit:

Before:

```
Benchmark                                  Mode  Cnt      Score   Error  Units
ParserBenchmark.parseComplexPattern       thrpt    2  30962,610          ops/s
ParserBenchmark.parseNamedCapturingGroup  thrpt    2  55060,607          ops/s
ParserBenchmark.parseNestedNonCapturing   thrpt    2  65521,538          ops/s
ParserBenchmark.parseSimplePattern        thrpt    2  85261,827          ops/s
```

After:

```
Benchmark                                  Mode  Cnt       Score   Error  Units
ParserBenchmark.parseComplexPattern       thrpt    2   48827,847          ops/s
ParserBenchmark.parseNamedCapturingGroup  thrpt    2  117731,514          ops/s
ParserBenchmark.parseNestedNonCapturing   thrpt    2  134201,675          ops/s
ParserBenchmark.parseSimplePattern        thrpt    2  247308,245          ops/s
```