### PR TITLE
perf(parser): derive positions from offsets for single-line patterns

### DIFF
--- a/core/src/main/scala/weaponregex/internal/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/Parser.scala
@@ -22,14 +22,18 @@ private[weaponregex] object Parser {
     *   A `Right` of parsed [[weaponregex.internal.model.regextree.RegexTree]] if can be parsed, a `Left` with the error
     *   message otherwise
     */
-  def apply(pattern: String, flags: Option[String], flavor: ParserFlavor): Either[String, RegexTree] =
+  def apply(pattern: String, flags: Option[String], flavor: ParserFlavor): Either[String, RegexTree] = {
+    // A pattern without a line break has `line` 0 and `col` == offset everywhere, so positions can be
+    // computed from the parser offset alone. Patterns with a line break use the caret-based parsers.
+    val singleLine: Boolean = pattern.indexOf('\n') < 0
     flavor match {
       case ParserFlavorJVM =>
         if (flags.isDefined) Left(ErrorMessage.jvmWithStringFlags)
-        else ParserJVM.parse(pattern)
-      case ParserFlavorJS => ParserJS(flags).parse(pattern)
+        else ParserJVM(singleLine).parse(pattern)
+      case ParserFlavorJS => ParserJS(flags, singleLine).parse(pattern)
       case null           => Left(ErrorMessage.unsupportedFlavor)
     }
+  }
 
   /** Apply the parser to parse the given pattern
     * @param pattern
@@ -46,7 +50,7 @@ private[weaponregex] object Parser {
   * @note
   *   The parsing rules methods inside this class is created based on the defined grammar
   */
-abstract private[weaponregex] class Parser {
+abstract private[weaponregex] class Parser(singleLine: Boolean) {
 
   /** Regex special characters
     */
@@ -89,7 +93,10 @@ abstract private[weaponregex] class Parser {
     *   A tuple of the `mutationtesting.Location` of the parse, and the return of the given parser `p`
     */
   protected def indexed[A](p: P[A]): P[(Location, A)] =
-    (position.with1 ~ p ~ position).map { case ((i, a), j) => (Location(i, j), a) }
+    if (singleLine) (P.index.with1 ~ p ~ P.index).map { case ((i, a), j) => (flatLocation(i, j), a) }
+    else (position.with1 ~ p ~ position).map { case ((i, a), j) => (Location(i, j), a) }
+
+  private def flatLocation(start: Int, end: Int): Location = Location(Position(0, start), Position(0, end))
 
   /** A higher order parser that add `mutationtesting.Location` index information of the parse of the given parser
     * @param p
@@ -98,7 +105,8 @@ abstract private[weaponregex] class Parser {
     *   A tuple of the `mutationtesting.Location` of the parse, and the return of the given parser `p`
     */
   protected def indexed0[A](p: P0[A]): P0[(Location, A)] =
-    (position ~ p ~ position).map { case ((i, a), j) => (Location(i, j), a) }
+    if (singleLine) (P.index ~ p ~ P.index).map { case ((i, a), j) => (flatLocation(i, j), a) }
+    else (position ~ p ~ position).map { case ((i, a), j) => (Location(i, j), a) }
 
   protected val backslash: P[Unit] = P.char('\\')
 

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
@@ -15,7 +15,8 @@ import weaponregex.internal.model.regextree.*
   * @see
   *   [[https://tc39.es/ecma262/multipage/text-processing.html#sec-patterns]]
   */
-private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean) extends Parser {
+private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean, singleLine: Boolean)
+    extends Parser(singleLine) {
 
   /** Regex special characters
     */
@@ -181,9 +182,12 @@ object ParserJS {
   private def unicodeMode(flags: Option[String]): Boolean = flags.exists(f => f.contains('u') || f.contains('v'))
 
   // Create lazy instances so all parsers are only instantiated once
-  private lazy val unicodeParser: ParserJS = new ParserJS(true)
-  private lazy val nonUnicodeParser: ParserJS = new ParserJS(false)
+  private lazy val unicodeParser: ParserJS = new ParserJS(true, false)
+  private lazy val nonUnicodeParser: ParserJS = new ParserJS(false, false)
+  private lazy val unicodeSingleLineParser: ParserJS = new ParserJS(true, true)
+  private lazy val nonUnicodeSingleLineParser: ParserJS = new ParserJS(false, true)
 
-  private[parser] def apply(flags: Option[String] = None): ParserJS =
-    if (unicodeMode(flags)) unicodeParser else nonUnicodeParser
+  private[parser] def apply(flags: Option[String] = None, singleLine: Boolean = false): ParserJS =
+    if (unicodeMode(flags)) { if (singleLine) unicodeSingleLineParser else unicodeParser }
+    else { if (singleLine) nonUnicodeSingleLineParser else nonUnicodeParser }
 }

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJVM.scala
@@ -10,7 +10,7 @@ import weaponregex.internal.model.regextree.*
   * @see
   *   [[https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html]]
   */
-private[weaponregex] object ParserJVM extends Parser {
+private[weaponregex] class ParserJVM private[parser] (singleLine: Boolean) extends Parser(singleLine) {
 
   /** Regex special characters
     */
@@ -129,4 +129,12 @@ private[weaponregex] object ParserJVM extends Parser {
         lookaround.backtrack ::
         atomicGroup.backtrack :: Nil
     )
+}
+
+object ParserJVM {
+  private lazy val singleLineParser: ParserJVM = new ParserJVM(true)
+  private lazy val multiLineParser: ParserJVM = new ParserJVM(false)
+
+  private[parser] def apply(singleLine: Boolean): ParserJVM =
+    if (singleLine) singleLineParser else multiLineParser
 }

--- a/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
@@ -158,6 +158,70 @@ trait ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Parse single line with location") {
+    val pattern = "ab+"
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
+
+    parsedTree.children zip Seq((0, 1), (1, 3)) foreach { case (node, (startColumn, endColumn)) =>
+      assertEquals(clue(node).location.start.line, 0)
+      assertEquals(clue(node).location.start.column, startColumn)
+      assertEquals(clue(node).location.end.line, 0)
+      assertEquals(clue(node).location.end.column, endColumn)
+    }
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse token spanning a line break with location") {
+    val pattern = "[a\nb]c"
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
+
+    val charClass = parsedTree.children.head.to[CharacterClass]
+    assertEquals(clue(charClass).location.start.line, 0)
+    assertEquals(clue(charClass).location.start.column, 0)
+    assertEquals(clue(charClass).location.end.line, 1)
+    assertEquals(clue(charClass).location.end.column, 2)
+
+    val lineBreak = charClass.children(1)
+    assertEquals(clue(lineBreak).location.start.line, 0)
+    assertEquals(clue(lineBreak).location.start.column, 2)
+    assertEquals(clue(lineBreak).location.end.line, 1)
+    assertEquals(clue(lineBreak).location.end.column, 0)
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
+  test("Parse an escaped line break with location") {
+    val pattern = """abc\ndef"""
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
+
+    assertMatches(clue(parsedTree.children)) {
+      case Seq(
+            Character('a', _),
+            Character('b', _),
+            Character('c', _),
+            MetaChar("n", _),
+            Character('d', _),
+            Character('e', _),
+            Character('f', _)
+          ) =>
+        true
+    }
+
+    val escape = parsedTree.children(3)
+    assertEquals(clue(escape).location.start.line, 0)
+    assertEquals(clue(escape).location.start.column, 3)
+    assertEquals(clue(escape).location.end.line, 0)
+    assertEquals(clue(escape).location.end.column, 5)
+
+    parsedTree.children foreach { node =>
+      assertEquals(clue(node).location.start.line, 0)
+      assertEquals(clue(node).location.end.line, 0)
+    }
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
   test("Parse positive character class with characters") {
     val pattern = "[abc]"
     val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[CharacterClass]


### PR DESCRIPTION
Use `.index` on single-line patterns, it has better performance compared to using `caret` twice.
