### PR TITLE
perf(parser): cut the cost of failing alternatives

### DIFF
--- a/core/src/main/scala/weaponregex/internal/parser/Parser.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/Parser.scala
@@ -135,7 +135,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val charLiteral: P[Character] =
     indexed(P.defer(P.charWhere(c => !specialChars.contains(c)) | charLiteralSpecialCases))
       .map { case (loc, c) => Character(c, loc) }
-      .withContext("character literal")
 
   /** Intermediate parsing rule for character-related tokens which can parse either `metaCharacter` or `charLiteral`
     * @return
@@ -152,7 +151,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val bol: P[BOL] =
     indexed(P.char('^'))
       .map { case (loc, _) => BOL(loc) }
-      .withContext("beginning of line")
 
   /** Parse a beginning of line character (`$`)
     * @return
@@ -163,7 +161,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val eol: P[EOL] =
     indexed(P.char('$'))
       .map { case (loc, _) => EOL(loc) }
-      .withContext("end of line")
 
   /** Parse a boundary meta-character character
     * @return
@@ -176,7 +173,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val boundaryMetaChar: P[Boundary] =
     indexed(backslash *> P.defer(P.charIn(boundaryMetaChars)))
       .map { case (loc, b) => Boundary(b, loc) }
-      .withContext("boundary meta-character")
 
   /** Intermediate parsing rule for boundary tokens which can parse either `bol`, `eol` or `boundaryMetaChar`
     * @return
@@ -212,7 +208,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val escapeChar: P[MetaChar] =
     indexed(backslash *> P.defer(P.charIn(escapeChars)))
       .map { case (loc, c) => MetaChar(c.toString(), loc) }
-      .withContext("escape character")
 
   /** Parse an control meta-character based on caret notation
     * @return
@@ -225,7 +220,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val controlChar: P[ControlChar] =
     indexed(P.string("\\c") *> alpha)
       .map { case (loc, c) => ControlChar(c, loc) }
-      .withContext("control character")
 
   /** Parse a character with octal value
     * @return
@@ -244,7 +238,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val charHex: P[MetaChar] =
     indexed(P.string("\\x") *> hexdig.repExactlyAs[String](2))
       .map { case (loc, hexDigits) => MetaChar("x" + hexDigits, loc) }
-      .withContext("hexadecimal character")
 
   /** Parse a unicode character `\ uhhhh`
     * @return
@@ -255,7 +248,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val charUnicode: P[MetaChar] =
     indexed(P.string("\\u") *> hexdig.repExactlyAs[String](4))
       .map { case (loc, hexDigits) => MetaChar("u" + hexDigits, loc) }
-      .withContext("unicode character")
 
   /** Parse a character with a code point `\x{h...h}`, where Character.MIN_CODE_POINT <= 0xh...h <=
     * Character.MAX_CODE_POINT and x is [[weaponregex.internal.parser.Parser#codePointEscChar]]
@@ -273,7 +265,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
           P.pure(MetaChar(s"$codePointEscChar{$hexDigits}", loc))
         else P.failWith(s"Invalid code point: $hexDigits")
       }
-      .withContext("code point character")
 
   /** Used to consume a hexadecimal escape character `\ x` or `\ u` when all other hex related cases are checked and
     * failed to prevent back tracking.
@@ -296,7 +287,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val range: P[Range] =
     P.defer(charClassCharLiteral ~ (P.char('-') *> charClassCharLiteral))
       .map { case (from, to) => Range(from, to, from.location.copy(end = to.location.end)) }
-      .withContext("character range")
 
   /** Parse special cases of a character literal in a character class
     * @return
@@ -315,25 +305,48 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val charClassCharLiteral: P[Character] =
     indexed(P.defer(P.charWhere(c => !charClassSpecialChars.contains(c)) | charClassCharLiteralSpecialCases))
       .map { case (loc, c) => Character(c, loc) }
-      .withContext("character literal in character class")
 
-  /** Intermediate parsing rule for character class item tokens which can parse either `charClass`,
-    * `preDefinedCharClass`, `metaCharacter`, `range`, `quoteChar`, or `charClassCharLiteral`
+  /** The `classItem` alternatives that start with a backslash
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
+    * @see
+    *   [[weaponregex.internal.parser.Parser.classItem]]
     */
-  protected val classItem: P[RegexTree] = P.defer(
+  protected val backslashClassItem: P[RegexTree] = P.defer(
     P.oneOf(
-      range.backtrack ::
-        charClassCharLiteral.backtrack ::
-        charClass.backtrack ::
-        preDefinedCharClass.backtrack ::
+      preDefinedCharClass.backtrack ::
         unicodeCharClass.backtrack ::
         metaCharacter.backtrack ::
         hexEscCharConsumer ::
         octEscCharConsumer ::
         quoteChar.backtrack :: Nil
     )
+  )
+
+  /** The `classItem` alternatives that never start with a backslash
+    * @return
+    *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
+    * @see
+    *   [[weaponregex.internal.parser.Parser.classItem]]
+    */
+  protected val plainClassItem: P[RegexTree] = P.defer(
+    P.oneOf(
+      range.backtrack ::
+        charClassCharLiteral.backtrack ::
+        charClass.backtrack :: Nil
+    )
+  )
+
+  /** Intermediate parsing rule for character class item tokens which can parse either `charClass`,
+    * `preDefinedCharClass`, `metaCharacter`, `range`, `quoteChar`, or `charClassCharLiteral`
+    * @return
+    *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
+    * @note
+    *   The alternatives are split on their first character, so a backslash only tries the escape rules and any other
+    *   character only tries the rest
+    */
+  protected val classItem: P[RegexTree] = P.defer(
+    (P.peek(backslash).with1 *> backslashClassItem) | (P.not(backslash).with1 *> plainClassItem)
   )
 
   /** Parse a character class
@@ -363,7 +376,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val anyDot: P[AnyDot] =
     indexed(P.char('.').void)
       .map { case (loc, _) => AnyDot(loc) }
-      .withContext("any dot")
 
   /** Parse a predefined character class
     * @return
@@ -648,7 +660,6 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
   protected val quoteChar: P[QuoteChar] =
     indexed(backslash *> P.anyChar)
       .map { case (loc, char) => QuoteChar(char, loc) }
-      .withContext("quoted character")
 
   /** Parse a 'long' quote, using `\Q` and `\E`
     * @return
@@ -671,22 +682,50 @@ abstract private[weaponregex] class Parser(singleLine: Boolean) {
     * `charClass`, `reference`, `character` or `quote`
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
+    * @note
+    *   The alternatives are split on their first character, so a backslash only tries the escape rules and any other
+    *   character only tries the rest
     */
   protected val elementaryRE: P[RegexTree] =
+    P.defer(
+      (P.peek(backslash).with1 *> backslashElementaryRE) | (P.not(backslash).with1 *> plainElementaryRE)
+    )
+
+  /** The `elementaryRE` alternatives that start with a backslash
+    * @return
+    *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
+    * @see
+    *   [[weaponregex.internal.parser.Parser.elementaryRE]]
+    */
+  protected val backslashElementaryRE: P[RegexTree] =
+    P.defer(
+      P.oneOf(
+        preDefinedCharClass.backtrack ::
+          unicodeCharClass.backtrack ::
+          boundaryMetaChar.backtrack ::
+          reference ::
+          metaCharacter.backtrack ::
+          hexEscCharConsumer ::
+          octEscCharConsumer ::
+          quote :: Nil
+      )
+    )
+
+  /** The `elementaryRE` alternatives that never start with a backslash
+    * @return
+    *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
+    * @see
+    *   [[weaponregex.internal.parser.Parser.elementaryRE]]
+    */
+  protected val plainElementaryRE: P[RegexTree] =
     P.defer(
       P.oneOf(
         charLiteral.backtrack ::
           capturing ::
           anyDot ::
-          preDefinedCharClass.backtrack ::
-          unicodeCharClass.backtrack ::
-          boundary ::
-          charClass.backtrack ::
-          reference ::
-          character ::
-          hexEscCharConsumer ::
-          octEscCharConsumer ::
-          quote :: Nil
+          bol ::
+          eol ::
+          charClass.backtrack :: Nil
       )
     )
 

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJS.scala
@@ -62,24 +62,29 @@ private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean, singl
     * @note
     *   Nested character class is a Scala/Java-only regex syntax
     */
-  override protected val classItem: P[RegexTree] =
+  override protected val backslashClassItem: P[RegexTree] =
     if (unicodeMode)
       P.oneOf(
-        range.backtrack ::
-          charClassCharLiteral.backtrack ::
-          preDefinedCharClass.backtrack ::
+        preDefinedCharClass.backtrack ::
           unicodeCharClass.backtrack ::
           P.defer(metaCharacter).backtrack ::
           quoteChar.backtrack :: Nil
       )
     else
       P.oneOf(
-        range.backtrack ::
-          charClassCharLiteral.backtrack ::
-          preDefinedCharClass.backtrack ::
+        preDefinedCharClass.backtrack ::
           P.defer(metaCharacter).backtrack ::
           quoteChar.backtrack :: Nil
       )
+
+  /** Intermediate parsing rule for character class item tokens that do not start with a backslash
+    * @return
+    *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
+    * @note
+    *   Nested character class is a Scala/Java-only regex syntax
+    */
+  override protected val plainClassItem: P[RegexTree] =
+    P.oneOf(range.backtrack :: charClassCharLiteral.backtrack :: Nil)
 
   /** Parse a group name
     * @return
@@ -102,7 +107,6 @@ private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean, singl
     if (unicodeMode)
       indexed(P.char('\\') *> P.charIn("""^$\.*+?()[]{}|/"""))
         .map { case (loc, char) => QuoteChar(char, loc) }
-        .withContext("quoted character")
     else quoteChar
 
   /** Parse a character with octal value `\n`, `\nn`, `\mnn` (0 <= m,n <= 9)
@@ -118,7 +122,6 @@ private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean, singl
   override protected val charOct: P[MetaChar] =
     indexed(P.char('\\') *> Numbers.digit.rep(1, 3).string)
       .map { case (loc, octDigits) => MetaChar(octDigits, loc) }
-      .withContext("octal character")
 
   /** Intermediate parsing rule for reference tokens which can parse only `nameReference`
     * @return
@@ -148,32 +151,38 @@ private[weaponregex] class ParserJS private[parser] (unicodeMode: Boolean, singl
     * @return
     *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
     */
-  override protected val elementaryRE: P[RegexTree] =
+  override protected val backslashElementaryRE: P[RegexTree] =
     if (unicodeMode)
       P.oneOf(
-        charLiteral.backtrack ::
-          capturing ::
-          anyDot ::
-          preDefinedCharClass.backtrack ::
+        preDefinedCharClass.backtrack ::
           unicodeCharClass.backtrack ::
-          boundary ::
-          charClass.backtrack ::
+          boundaryMetaChar.backtrack ::
           reference.backtrack ::
-          character.backtrack ::
+          P.defer(metaCharacter).backtrack ::
           quote :: Nil
       )
     else
       P.oneOf(
-        charLiteral.backtrack ::
-          capturing ::
-          anyDot ::
-          preDefinedCharClass.backtrack ::
-          boundary ::
-          charClass.backtrack ::
+        preDefinedCharClass.backtrack ::
+          boundaryMetaChar.backtrack ::
           reference.backtrack ::
-          character.backtrack ::
+          P.defer(metaCharacter).backtrack ::
           quote :: Nil
       )
+
+  /** Intermediate parsing rule which parses the alternatives that do not start with a backslash
+    * @return
+    *   [[weaponregex.internal.model.regextree.RegexTree]] (sub)tree
+    */
+  override protected val plainElementaryRE: P[RegexTree] =
+    P.oneOf(
+      charLiteral.backtrack ::
+        capturing ::
+        anyDot ::
+        bol ::
+        eol ::
+        charClass.backtrack :: Nil
+    )
 }
 
 object ParserJS {

--- a/core/src/main/scala/weaponregex/internal/parser/ParserJVM.scala
+++ b/core/src/main/scala/weaponregex/internal/parser/ParserJVM.scala
@@ -56,7 +56,6 @@ private[weaponregex] class ParserJVM private[parser] (singleLine: Boolean) exten
         .repExactlyAs[String](2)).string.backtrack | P.charIn('0' to '7').rep(1, 2).string)
     )
       .map { case (loc, octDigits) => MetaChar("0" + octDigits, loc) }
-      .withContext("octal character")
 
   /** Consume a `\0` that is not followed by valid octal digits so it hard-fails (matching `java.util.regex`, which
     * rejects a bare `\0`) instead of degrading into a quoted `0` character.

--- a/core/src/test/scala/weaponregex/internal/parser/ParserJSTest.scala
+++ b/core/src/test/scala/weaponregex/internal/parser/ParserJSTest.scala
@@ -144,12 +144,12 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
       """|\x{20}
          | ^
          |expectations:
-         |* context: quoted character, must be char: '$'
-         |* context: quoted character, must be a char within the range of: ['(', '+']
-         |* context: quoted character, must be a char within the range of: ['.', '/']
-         |* context: quoted character, must be char: '?'
-         |* context: quoted character, must be a char within the range of: ['[', '^']
-         |* context: quoted character, must be a char within the range of: ['{', '}']""".stripMargin,
+         |* must be char: '$'
+         |* must be a char within the range of: ['(', '+']
+         |* must be a char within the range of: ['.', '/']
+         |* must be char: '?'
+         |* must be a char within the range of: ['[', '^']
+         |* must be a char within the range of: ['{', '}']""".stripMargin,
       Some("u")
     )
     parseErrorTest(
@@ -157,12 +157,12 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
       """|\x{20}
          | ^
          |expectations:
-         |* context: quoted character, must be char: '$'
-         |* context: quoted character, must be a char within the range of: ['(', '+']
-         |* context: quoted character, must be a char within the range of: ['.', '/']
-         |* context: quoted character, must be char: '?'
-         |* context: quoted character, must be a char within the range of: ['[', '^']
-         |* context: quoted character, must be a char within the range of: ['{', '}']""".stripMargin,
+         |* must be char: '$'
+         |* must be a char within the range of: ['(', '+']
+         |* must be a char within the range of: ['.', '/']
+         |* must be char: '?'
+         |* must be a char within the range of: ['[', '^']
+         |* must be a char within the range of: ['{', '}']""".stripMargin,
       Some("v")
     )
   }
@@ -175,12 +175,12 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
       s"""|\\u20
           | ^
           |expectations:
-          |* context: quoted character, must be char: '$dollar'
-          |* context: quoted character, must be a char within the range of: ['(', '+']
-          |* context: quoted character, must be a char within the range of: ['.', '/']
-          |* context: quoted character, must be char: '?'
-          |* context: quoted character, must be a char within the range of: ['[', '^']
-          |* context: quoted character, must be a char within the range of: ['{', '}']""".stripMargin,
+          |* must be char: '$dollar'
+          |* must be a char within the range of: ['(', '+']
+          |* must be a char within the range of: ['.', '/']
+          |* must be char: '?'
+          |* must be a char within the range of: ['[', '^']
+          |* must be a char within the range of: ['{', '}']""".stripMargin,
       Some("u")
     )
     parseErrorTest(
@@ -188,12 +188,12 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
       s"""|\\u20
           | ^
           |expectations:
-          |* context: quoted character, must be char: '$dollar'
-          |* context: quoted character, must be a char within the range of: ['(', '+']
-          |* context: quoted character, must be a char within the range of: ['.', '/']
-          |* context: quoted character, must be char: '?'
-          |* context: quoted character, must be a char within the range of: ['[', '^']
-          |* context: quoted character, must be a char within the range of: ['{', '}']""".stripMargin,
+          |* must be char: '$dollar'
+          |* must be a char within the range of: ['(', '+']
+          |* must be a char within the range of: ['.', '/']
+          |* must be char: '?'
+          |* must be a char within the range of: ['[', '^']
+          |* must be a char within the range of: ['{', '}']""".stripMargin,
       Some("v")
     )
   }
@@ -206,12 +206,12 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
       s"""|\\u{110000}
           | ^
           |expectations:
-          |* context: quoted character, must be char: '$dollar'
-          |* context: quoted character, must be a char within the range of: ['(', '+']
-          |* context: quoted character, must be a char within the range of: ['.', '/']
-          |* context: quoted character, must be char: '?'
-          |* context: quoted character, must be a char within the range of: ['[', '^']
-          |* context: quoted character, must be a char within the range of: ['{', '}']""".stripMargin,
+          |* must be char: '$dollar'
+          |* must be a char within the range of: ['(', '+']
+          |* must be a char within the range of: ['.', '/']
+          |* must be char: '?'
+          |* must be a char within the range of: ['[', '^']
+          |* must be a char within the range of: ['{', '}']""".stripMargin,
       Some("u")
     )
     parseErrorTest(
@@ -219,12 +219,12 @@ class ParserJSTest extends munit.FunSuite with ParserTest {
       s"""|\\u{110000}
           | ^
           |expectations:
-          |* context: quoted character, must be char: '$dollar'
-          |* context: quoted character, must be a char within the range of: ['(', '+']
-          |* context: quoted character, must be a char within the range of: ['.', '/']
-          |* context: quoted character, must be char: '?'
-          |* context: quoted character, must be a char within the range of: ['[', '^']
-          |* context: quoted character, must be a char within the range of: ['{', '}']""".stripMargin,
+          |* must be char: '$dollar'
+          |* must be a char within the range of: ['(', '+']
+          |* must be a char within the range of: ['.', '/']
+          |* must be char: '?'
+          |* must be a char within the range of: ['[', '^']
+          |* must be a char within the range of: ['{', '}']""".stripMargin,
       Some("v")
     )
   }

--- a/core/src/test/scala/weaponregex/internal/parser/ParserJVMTest.scala
+++ b/core/src/test/scala/weaponregex/internal/parser/ParserJVMTest.scala
@@ -412,12 +412,11 @@ class ParserJVMTest extends munit.FunSuite with ParserTest {
       """|{
          |^""".stripMargin,
       context = Seq(
-        "unicode character",
-        "code point character",
-        "unicode character class",
         "flag toggle group",
+        "flag non-capturing group",
         "atomic group",
-        "long quote"
+        "capturing group",
+        "character class"
       )
     )
   }

--- a/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
@@ -221,6 +221,26 @@ trait ParserTest {
     treeBuildTest(parsedTree, pattern)
   }
 
+  test("Parse backslash and non-backslash tokens next to each other") {
+    val pattern = """^a\t.[b\t]+(\t)$"""
+    val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[Concat]
+
+    assertMatches(clue(parsedTree.children)) {
+      case Seq(
+            BOL(_),
+            Character('a', _),
+            MetaChar("t", _),
+            AnyDot(_),
+            OneOrMore(CharacterClass(Seq(Character('b', _), MetaChar("t", _)), _, true), _, GreedyQuantifier),
+            Group(MetaChar("t", _), true, _),
+            EOL(_)
+          ) =>
+        true
+    }
+
+    treeBuildTest(parsedTree, pattern)
+  }
+
   test("Parse positive character class with characters") {
     val pattern = "[abc]"
     val parsedTree = Parser(pattern, parserFlavor).getOrFail.to[CharacterClass]
@@ -674,23 +694,10 @@ trait ParserTest {
       """|(a{1,2}
          |^""".stripMargin,
       context = Seq(
-        "character literal",
-        "beginning of line",
-        "end of line",
-        "boundary meta-character",
-        "escape character",
-        "control character",
-        "hexadecimal character",
-        "any dot",
-        "predefined character class",
         "capturing group",
         "named capturing group",
         "non-capturing group",
         "lookaround",
-        "named reference",
-        "quoted character",
-        "quoted character",
-        "octal character",
         "character class"
       )
     )


### PR DESCRIPTION
Two changes:

- `.peek` on `backslash`es for options that all have a backslash, to only parse once on failures.
- Remove `.withContext` chains to lower-level ones that often fail.
