### PR TITLE
perf(model): cache the built string on each tree node

### DIFF
--- a/core/src/main/scala/weaponregex/internal/TokenMutatorSyntax.scala
+++ b/core/src/main/scala/weaponregex/internal/TokenMutatorSyntax.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal
 
 import mutationtesting.Location
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.model.regextree.{Node, RegexTree}
 import weaponregex.model.mutation.{Mutant, TokenMutator as BaseTokenMutator}
 

--- a/core/src/main/scala/weaponregex/internal/extension/RegexTreeExtension.scala
+++ b/core/src/main/scala/weaponregex/internal/extension/RegexTreeExtension.scala
@@ -9,16 +9,10 @@ import weaponregex.mutator.BuiltinMutators
 private[weaponregex] object RegexTreeExtension {
 
   /** The extension that build a given [[weaponregex.internal.model.regextree.RegexTree]] into a string
+    * @note
+    *   The tree itself builds into a string through [[weaponregex.internal.model.regextree.RegexTree.build]]
     */
-  implicit class RegexTreeStringBuilder(tree: RegexTree) {
-
-    /** Build the tree into a String
-      */
-    lazy val build: String = tree match {
-      case leaf: Leaf[?]  => leaf.prefix + leaf.value + leaf.postfix
-      case ft: FlagToggle => ft.onFlags.build + (if (ft.hasDash) "-" else "") + ft.offFlags.build
-      case _              => buildWhile(_ => true)
-    }
+  implicit class RegexTreeStringBuilder(val tree: RegexTree) extends AnyVal {
 
     /** Build the tree into a String with a child replaced by a string.
       * @param child
@@ -33,7 +27,7 @@ private[weaponregex] object RegexTreeExtension {
         node.children
           .map(c => if (c eq child) childString else c.build)
           .mkString(node.prefix, node.sep, tree.postfix)
-      case _ => build
+      case _ => tree.build
     }
 
     /** Build the tree into a String while a predicate holds for a given child.
@@ -48,7 +42,7 @@ private[weaponregex] object RegexTreeExtension {
           .filter(pred)
           .map(_.build)
           .mkString(tree.prefix, node.sep, tree.postfix)
-      case _ => build
+      case _ => tree.build
     }
   }
 

--- a/core/src/main/scala/weaponregex/internal/model/regextree/capturingNode.scala
+++ b/core/src/main/scala/weaponregex/internal/model/regextree/capturingNode.scala
@@ -62,7 +62,12 @@ case class FlagToggleGroup(flagToggle: FlagToggle, override val location: Locati
   *   The `mutationtesting.Location` of the node in the regex string
   */
 case class FlagToggle(onFlags: Flags, hasDash: Boolean, offFlags: Flags, override val location: Location)
-    extends Node(Seq(onFlags, offFlags), location)
+    extends Node(Seq(onFlags, offFlags), location) {
+
+  /** The dash sits between the two children, which the generic `Node` separator cannot express
+    */
+  override protected def buildString: String = onFlags.build + (if (hasDash) "-" else "") + offFlags.build
+}
 
 /** A sequence of flags for use in [[weaponregex.internal.model.regextree.FlagToggle]]
   * @param flags

--- a/core/src/main/scala/weaponregex/internal/model/regextree/regexTree.scala
+++ b/core/src/main/scala/weaponregex/internal/model/regextree/regexTree.scala
@@ -17,6 +17,17 @@ sealed trait RegexTree {
   /** The `mutationtesting.Location` of the node in the regex string
     */
   def location: Location
+
+  /** The regex string that this (sub)tree represents.
+    *
+    * Building a mutant rewrites the pattern of every node between the mutated token and the root, so a subtree is built
+    * many times per mutation run. The result is computed once per node and reused after that.
+    */
+  final lazy val build: String = buildString
+
+  /** Compute the regex string that this (sub)tree represents, without using the [[build]] cache
+    */
+  protected def buildString: String
 }
 
 /** The non-terminal node of the [[weaponregex.internal.model.regextree.RegexTree]] that have at least one child node
@@ -37,7 +48,9 @@ abstract class Node(
     override val prefix: String = "",
     override val postfix: String = "",
     val sep: String = ""
-) extends RegexTree
+) extends RegexTree {
+  override protected def buildString: String = children.map(_.build).mkString(prefix, sep, postfix)
+}
 
 /** The leaf of the [[weaponregex.internal.model.regextree.RegexTree]] (terminal node) that have no children node
   * @param value
@@ -54,4 +67,6 @@ abstract class Leaf[A](
     override val location: Location,
     override val prefix: String = "",
     override val postfix: String = ""
-) extends RegexTree
+) extends RegexTree {
+  override protected def buildString: String = prefix + value + postfix
+}

--- a/core/src/main/scala/weaponregex/internal/mutator/capturingMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/capturingMutator.scala
@@ -3,7 +3,6 @@ package weaponregex.internal.mutator
 import cats.data.NonEmptySet
 import mutationtesting.Location
 import weaponregex.internal.TokenMutator
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.model.regextree.*
 import weaponregex.model.mutation.Mutant
 

--- a/core/src/main/scala/weaponregex/internal/mutator/predefCharClassMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/predefCharClassMutator.scala
@@ -3,7 +3,6 @@ package weaponregex.internal.mutator
 import cats.data.NonEmptySet
 import mutationtesting.Location
 import weaponregex.internal.TokenMutator
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.extension.StringExtension.*
 import weaponregex.internal.model.regextree.*
 import weaponregex.model.mutation.Mutant

--- a/core/src/main/scala/weaponregex/internal/mutator/quantifierMutator.scala
+++ b/core/src/main/scala/weaponregex/internal/mutator/quantifierMutator.scala
@@ -3,7 +3,6 @@ package weaponregex.internal.mutator
 import cats.data.NonEmptySet
 import mutationtesting.Location
 import weaponregex.internal.TokenMutator
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.model.regextree.*
 import weaponregex.model.mutation.Mutant
 

--- a/core/src/test/scala/weaponregex/internal/model/regextree/BoundaryNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/BoundaryNodeTest.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal.model.regextree
 
 import weaponregex.internal.constant.RegexTreeStubs.LOCATION
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class BoundaryNodeTest extends munit.FunSuite {
   test("BOL build") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/CapturingNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/CapturingNodeTest.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal.model.regextree
 
 import weaponregex.internal.constant.RegexTreeStubs.*
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class CapturingNodeTest extends munit.FunSuite {
   test("Group build") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/CharacterClassNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/CharacterClassNodeTest.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal.model.regextree
 
 import weaponregex.internal.constant.RegexTreeStubs.*
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class CharacterClassNodeTest extends munit.FunSuite {
   test("CharacterClass build") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/CharacterNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/CharacterNodeTest.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal.model.regextree
 
 import weaponregex.internal.constant.RegexTreeStubs.LOCATION
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class CharacterNodeTest extends munit.FunSuite {
   test("Character build a") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/LogicalNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/LogicalNodeTest.scala
@@ -2,7 +2,6 @@ package weaponregex.internal.model.regextree
 
 import cats.data.NonEmptyList
 import weaponregex.internal.constant.RegexTreeStubs.*
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class LogicalNodeTest extends munit.FunSuite {
   test("Concat build") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/PredefinedCharClassNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/PredefinedCharClassNodeTest.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal.model.regextree
 
 import weaponregex.internal.constant.RegexTreeStubs.LOCATION
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class PredefinedCharClassNodeTest extends munit.FunSuite {
   test("PredefinedCharClass build") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/QuantifierNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/QuantifierNodeTest.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal.model.regextree
 
 import weaponregex.internal.constant.RegexTreeStubs.*
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class QuantifierNodeTest extends munit.FunSuite {
   test("Quantifier build") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/QuotationNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/QuotationNodeTest.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal.model.regextree
 
 import weaponregex.internal.constant.RegexTreeStubs.LOCATION
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class QuotationNodeTest extends munit.FunSuite {
   test("QuoteChar build") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/ReferenceNodeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/ReferenceNodeTest.scala
@@ -1,7 +1,6 @@
 package weaponregex.internal.model.regextree
 
 import weaponregex.internal.constant.RegexTreeStubs.LOCATION
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 
 class ReferenceNodeTest extends munit.FunSuite {
   test("NameReference build") {

--- a/core/src/test/scala/weaponregex/internal/model/regextree/RegexTreeTest.scala
+++ b/core/src/test/scala/weaponregex/internal/model/regextree/RegexTreeTest.scala
@@ -50,4 +50,37 @@ class RegexTreeTest extends munit.FunSuite {
     val buildResult = tree.build
     assertEquals(buildResult, pattern)
   }
+
+  test("RegexTree build is cached per node") {
+    val loc = LOCATION
+    val child = CharacterClass(Seq(Character('a', loc), Character('b', loc)), loc)
+    val tree = OneOrMore(child, loc, GreedyQuantifier)
+
+    assertEquals(tree.build, "[ab]+")
+    // The second call reuses the cached string instead of building it again
+    assert(tree.build eq tree.build)
+    assertEquals(tree.build, "[ab]+")
+  }
+
+  test("RegexTree build of an already built child is unaffected") {
+    val loc = LOCATION
+    val child = CharacterClass(Seq(Character('a', loc), Character('b', loc)), loc)
+    // Build the child before its parent, so the parent builds on top of a filled cache
+    assertEquals(child.build, "[ab]")
+
+    val tree = OneOrMore(child, loc, GreedyQuantifier)
+    assertEquals(tree.build, "[ab]+")
+    assertEquals(tree.buildWith(child, "[cd]"), "[cd]+")
+    // Replacing a child in one build does not disturb the cached strings
+    assertEquals(child.build, "[ab]")
+    assertEquals(tree.build, "[ab]+")
+  }
+
+  test("FlagToggle builds the dash between its flags") {
+    val loc = LOCATION
+    val flagToggle = FlagToggle(Flags(Seq(Character('i', loc)), loc), true, Flags(Seq(Character('x', loc)), loc), loc)
+
+    assertEquals(flagToggle.build, "i-x")
+    assertEquals(FlagToggleGroup(flagToggle, loc).build, "(?i-x)")
+  }
 }

--- a/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
+++ b/core/src/test/scala/weaponregex/internal/parser/ParserTest.scala
@@ -2,7 +2,6 @@ package weaponregex.internal.parser
 
 import munit.Location
 import weaponregex.internal.extension.EitherExtension.LeftStringEitherTest
-import weaponregex.internal.extension.RegexTreeExtension.RegexTreeStringBuilder
 import weaponregex.internal.model.regextree.*
 import weaponregex.parser.ParserFlavor
 


### PR DESCRIPTION
Move `build` from the `RegexTreeStringBuilder` to `RegexTree` lazy val
